### PR TITLE
Visit all children nodes of custom tags

### DIFF
--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -13,8 +13,9 @@ class VisitorTest < Minitest::Test
       method.start_with?("on_") || method.start_with?("after_") || super
     end
 
-    def method_missing(method, *)
+    def method_missing(method, node)
       @calls << method
+      @calls << node.value if node.literal?
     end
 
     def respond_to_missing?(_method_name, _include_private = false)
@@ -45,18 +46,18 @@ class VisitorTest < Minitest::Test
       :on_tag,
       :on_assign,
       :on_variable,
-      :on_string,
+      :on_string, "hello",
       :after_variable,
       :after_assign,
       :after_tag,
-      :on_string,
-      :after_document,
+      :on_string, "\n",
+      :after_document
     ], @tracer.calls)
   end
 
   def test_if
     template = parse_liquid(<<~END)
-      {% if x == 'hello' %}
+      {% if x == 'condition' %}
         {% assign x = 'hello' %}
       {% else %}
       {% endif %}
@@ -69,12 +70,12 @@ class VisitorTest < Minitest::Test
       :on_condition,
       :on_variable_lookup,
       :after_variable_lookup,
-      :on_string,
+      :on_string, "condition",
       :on_block_body,
       :on_tag,
       :on_assign,
       :on_variable,
-      :on_string,
+      :on_string, "hello",
       :after_variable,
       :after_assign,
       :after_tag,
@@ -86,17 +87,15 @@ class VisitorTest < Minitest::Test
       :after_else_condition,
       :after_if,
       :after_tag,
-      :on_string,
-      :after_document,
+      :on_string, "\n",
+      :after_document
     ], @tracer.calls)
   end
 
   def test_schema
     template = parse_liquid(<<~END)
       {% schema %}
-        {
-          "muffin": true
-        }
+        { "muffin": true }
       {% endschema %}
     END
     @visitor.visit_template(template)
@@ -104,11 +103,62 @@ class VisitorTest < Minitest::Test
       :on_document,
       :on_tag,
       :on_schema,
-      :on_string,
+      :on_string, "\n  { \"muffin\": true }\n",
       :after_schema,
       :after_tag,
-      :on_string,
-      :after_document,
+      :on_string, "\n",
+      :after_document
+    ], @tracer.calls)
+  end
+
+  def test_paginate
+    template = parse_liquid(<<~END)
+      {% paginate products by x %}
+        {{ product.name }}
+      {% endpaginate %}
+    END
+    @visitor.visit_template(template)
+    assert_equal([
+      :on_document,
+      :on_tag,
+      :on_paginate,
+      :on_string, "\n  ",
+      :on_variable,
+      :on_variable_lookup,
+      :on_string, "name",
+      :after_variable_lookup,
+      :after_variable,
+      :on_string, "\n",
+      :on_variable_lookup,
+      :after_variable_lookup,
+      :after_paginate,
+      :after_tag,
+      :on_string, "\n",
+      :after_document
+    ], @tracer.calls)
+  end
+
+  def test_form
+    template = parse_liquid(<<~END)
+      {% form 'type', object, key: value %}
+      {% endform %}
+    END
+    @visitor.visit_template(template)
+    assert_equal([
+      :on_document,
+      :on_tag,
+      :on_form,
+      :on_string, "\n",
+      :on_string, "type",
+      :on_variable_lookup,
+      :after_variable_lookup,
+      :on_string, "key",
+      :on_variable_lookup,
+      :after_variable_lookup,
+      :after_form,
+      :after_tag,
+      :on_string, "\n",
+      :after_document
     ], @tracer.calls)
   end
 end


### PR DESCRIPTION
Had some false positives while running on project-64k theme.

All because children nodes of custom tags were not visited.

Now all offenses on project-64k look very legit!