### PR TITLE
Check for extra & missing spaces inside {...}

### DIFF
--- a/lib/theme_check/check.rb
+++ b/lib/theme_check/check.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
+require_relative "parsing_helpers"
+
 module ThemeCheck
   class Check
+    include ParsingHelpers
+
     attr_accessor :theme
     attr_accessor :offenses
 

--- a/lib/theme_check/checks/liquid_tag.rb
+++ b/lib/theme_check/checks/liquid_tag.rb
@@ -12,8 +12,7 @@ module ThemeCheck
     end
 
     def on_tag(node)
-      # Already inside {% liquid ... %} ?
-      if !node.template.excerpt(node.line_number).start_with?("{%")
+      if !node.inside_liquid_tag?
         reset_consecutive_statements
       # Ignore comments
       elsif !node.comment?

--- a/lib/theme_check/checks/space_inside_braces.rb
+++ b/lib/theme_check/checks/space_inside_braces.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+module ThemeCheck
+  # Ensure {% ... %} & {{ ... }} have consistent spaces.
+  class SpaceInsideBraces < Check
+    severity :style
+
+    def initialize
+      @ignore = false
+    end
+
+    def on_node(node)
+      return unless node.markup
+
+      outside_of_strings(node.markup) do |chunk|
+        chunk.scan(/([,:])  +/) do |_match|
+          add_offense("Too many spaces after '#{Regexp.last_match(1)}'", node: node)
+        end
+        chunk.scan(/([,:])\S/) do |_match|
+          add_offense("Space missing after '#{Regexp.last_match(1)}'", node: node)
+        end
+      end
+    end
+
+    def on_tag(node)
+      if node.inside_liquid_tag?
+        if node.markup[-1] != " " && node.markup[-1] != "\n"
+          add_offense("Space missing at the end of {% ... %}", node: node)
+        elsif node.markup =~ /(\n?)  +\z/m && Regexp.last_match[1] != "\n"
+          add_offense("Too many spaces at the end of {% ... %}", node: node)
+        end
+      end
+      @ignore = true
+    end
+
+    def after_tag(_node)
+      @ignore = false
+    end
+
+    def on_variable(node)
+      return if @ignore
+      if node.markup[0] != " "
+        add_offense("Space missing at the start of {{ ... }}", node: node)
+      elsif node.markup[-1] != " "
+        add_offense("Space missing at the end of {{ ... }}", node: node)
+      elsif node.markup[1] == " "
+        add_offense("Too many spaces at the start of {{ ... }}", node: node)
+      elsif node.markup[-2] == " "
+        add_offense("Too many spaces at the end of {{ ... }}", node: node)
+      end
+    end
+  end
+end

--- a/lib/theme_check/node.rb
+++ b/lib/theme_check/node.rb
@@ -12,6 +12,14 @@ module ThemeCheck
       @template = template
     end
 
+    def markup
+      if tag?
+        @value.raw
+      elsif @value.instance_variable_defined?(:@markup)
+        @value.instance_variable_get(:@markup)
+      end
+    end
+
     def children
       @children ||= begin
         nodes =
@@ -73,6 +81,14 @@ module ThemeCheck
 
     def type_name
       @type_name ||= @value.class.name.demodulize.underscore.to_sym
+    end
+
+    def inside_liquid_tag?
+      if line_number
+        template.excerpt(line_number).start_with?("{%")
+      else
+        false
+      end
     end
   end
 end

--- a/lib/theme_check/parsing_helpers.rb
+++ b/lib/theme_check/parsing_helpers.rb
@@ -1,0 +1,16 @@
+module ThemeCheck
+  module ParsingHelpers
+    # Yield each chunk outside of "...", '...'
+    def outside_of_strings(markup)
+      scanner = StringScanner.new(markup)
+
+      while scanner.scan(/.*?("|')/)
+        yield scanner.matched[..-2]
+        # Skip to the end of the string
+        scanner.skip_until(scanner.matched[-1] == "'" ? /[^\\]'/ : /[^\\]"/)
+      end
+
+      yield scanner.rest if scanner.rest?
+    end
+  end
+end

--- a/lib/theme_check/visitor.rb
+++ b/lib/theme_check/visitor.rb
@@ -13,12 +13,14 @@ module ThemeCheck
     end
 
     def visit(node)
+      call_checks(:on_node, node)
       call_checks(:on_tag, node) if node.tag?
       call_checks(:"on_#{node.type_name}", node)
       node.children.each { |child| visit(child) }
       unless node.literal?
         call_checks(:"after_#{node.type_name}", node)
         call_checks(:after_tag, node) if node.tag?
+        call_checks(:after_node, node)
       end
     end
 

--- a/test/checks/space_inside_braces_test.rb
+++ b/test/checks/space_inside_braces_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class SpaceInsideBracesTest < Minitest::Test
+  def test_reports_missing_space
+    offenses = analyze_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {% assign x = 1%}
+        {{ x}}
+        {{x }}
+      END
+    )
+    assert_equal(<<~END.chomp, offenses.join("\n"))
+      Space missing at the end of {% ... %} at templates/index.liquid:1
+      Space missing at the end of {{ ... }} at templates/index.liquid:2
+      Space missing at the start of {{ ... }} at templates/index.liquid:3
+    END
+  end
+
+  def test_reports_extra_space
+    offenses = analyze_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {{  x }}
+        {% assign x = 1  %}
+        {{ x  }}
+      END
+    )
+    assert_equal(<<~END.chomp, offenses.join("\n"))
+      Too many spaces at the start of {{ ... }} at templates/index.liquid:1
+      Too many spaces at the end of {% ... %} at templates/index.liquid:2
+      Too many spaces at the end of {{ ... }} at templates/index.liquid:3
+    END
+  end
+
+  def test_reports_extra_space_around_coma
+    offenses = analyze_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {% form 'type',  object, key:value %}
+        {% endform %}
+      END
+    )
+    assert_equal(<<~END.chomp, offenses.join("\n"))
+      Too many spaces after ',' at templates/index.liquid:1
+      Space missing after ':' at templates/index.liquid:1
+    END
+  end
+
+  def test_dont_report_with_proper_spaces
+    offenses = analyze_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {% assign x = 1 %}
+        {{ x }}
+        {% form 'type', object, key: value, key2: value %}
+        {% endform %}
+        {{ "ignore:stuff,  indeed" }}
+        {% render 'product-card',
+          product_card_product: product_recommendation,
+          show_vendor: section.settings.show_vendor,
+          media_size: section.settings.product_recommendations_image_ratio,
+          center_align_text: section.settings.center_align_text
+        %}
+            {% render 'product-card',
+              product_card_product: product,
+              show_vendor: section.settings.show_vendor,
+              media_size: section.settings.product_image_ratio,
+              center_align_text: section.settings.center_align_text,
+              show_full_details: true
+            %}
+      END
+    )
+    assert_equal("", offenses.join("\n"))
+  end
+end

--- a/test/parsing_helpers_test.rb
+++ b/test/parsing_helpers_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class ParsingHelpersTest < Minitest::Test
+  include ThemeCheck::ParsingHelpers
+
+  def test_outside_of_strings
+    chunks = []
+    outside_of_strings("1'\"2'3\"4\"") { |chunk| chunks << chunk }
+    assert_equal(["1", "3"], chunks)
+  end
+end


### PR DESCRIPTION
See https://github.com/Shopify/theme-check/pull/21/files#diff-20411f3be0235d27648f9c1aa4557b8b6f3ece1f0b9560cba6080704106aa8bf for examples.

Fixes #15.

But doesn't check for spaces at the start of tags `{%<here>... %}`, because Liquid drops all those in the AST.