### PR TITLE
Add check for required tags in layout/theme.liquid

### DIFF
--- a/lib/theme_check/checks/required_layout_theme_object.rb
+++ b/lib/theme_check/checks/required_layout_theme_object.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+module ThemeCheck
+  # Reports missing content_for_header and content_for_layout in theme.liquid
+  class RequiredLayoutThemeObject < Check
+    severity :error
+    doc "https://shopify.dev/docs/themes/theme-templates/theme-liquid"
+
+    LAYOUT_FILENAME = "layout/theme"
+
+    def initialize
+      @content_for_layout_found = false
+      @content_for_header_found = false
+    end
+
+    def on_document(node)
+      @layout_theme_node = node if node.template.name == LAYOUT_FILENAME
+    end
+
+    def on_variable(node)
+      return unless node.value.name.is_a?(Liquid::VariableLookup)
+
+      @content_for_header_found ||= node.value.name.name == "content_for_header"
+      @content_for_layout_found ||= node.value.name.name == "content_for_layout"
+    end
+
+    def after_document(node)
+      return unless node.template.name == LAYOUT_FILENAME
+
+      add_missing_object_offense("content_for_layout") unless @content_for_layout_found
+      add_missing_object_offense("content_for_header") unless @content_for_header_found
+    end
+
+    private
+
+    def add_missing_object_offense(name)
+      add_offense("#{LAYOUT_FILENAME} must include {{#{name}}}", node: @layout_theme_node)
+    end
+  end
+end

--- a/test/checks/required_layout_theme_object_test.rb
+++ b/test/checks/required_layout_theme_object_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class RequiredLayoutThemeObjectTest < Minitest::Test
+  def test_do_not_report_when_required_objects_are_present
+    offenses = analyze_layout_theme(
+      <<~END
+        {{content_for_header}}
+        {{content_for_layout}}
+      END
+    )
+
+    assert_equal("", offenses.join)
+  end
+
+  def test_picks_up_variable_lookups_only
+    offenses = analyze_layout_theme(
+      <<~END
+        {{"a"}}
+        {{"1"}}
+        {{ false }}
+        {{content_for_header}}
+        {{content_for_layout}}
+      END
+    )
+
+    assert_equal("", offenses.join)
+  end
+
+  def test_report_offense_on_missing_content_for_header
+    offenses = analyze_layout_theme("{{content_for_layout}}")
+
+    assert_equal(
+      "layout/theme must include {{content_for_header}} at layout/theme.liquid",
+      offenses.join
+    )
+  end
+
+  def test_report_offense_on_missing_content_for_layout
+    offenses = analyze_layout_theme("{{content_for_header}}")
+
+    assert_equal(
+      "layout/theme must include {{content_for_layout}} at layout/theme.liquid",
+      offenses.join
+    )
+  end
+
+  private
+
+  def analyze_layout_theme(content)
+    analyze_theme(
+      ThemeCheck::RequiredLayoutThemeObject.new,
+      "layout/theme.liquid" => content
+    )
+  end
+end


### PR DESCRIPTION
Fix #27

## On naming

I used _object_ to refer to the output tag with a variable in it, to match the [referenced public doc](https://shopify.dev/docs/themes/theme-templates/theme-liquid):

>There are two Liquid objects that are **required** in `theme.liquid` [...]

I'm a liquid-newbie, is that the correct nomeclature?

## On using `variable_lookup`

This approach is a bit naive, the check passes when `content_for_layout` is used somewhere, regardless of the context. Is it too naive?

Alternative approach: looking for `{{ }}` (not sure what that node is -- `variable`?), looking at the node's content, and maybe even ensuring there are no filters.

Both these approaches won't catch `content_for_*` being `assign`ed to a variable, but I think that's fine, right?