### PR TITLE
Add default config and config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ module ThemeCheck
 end
 ```
 
+Add the new check to `config/default.yml` to enable it.
+
+```yaml
+MyCheckName:
+  enabled: true
+```
+
 Add a corresponding test file under `test/checks`.
 
 When done, run the tests with `dev test`.

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,33 @@
+ConvertIncludeToRender:
+  enabled: true
+
+LiquidTag:
+  enabled: true
+
+MissingTemplate:
+  enabled: true
+
+NestedSnippet:
+  enabled: true
+
+RequiredLayoutThemeObject:
+  enabled: true
+
+SpaceInsideBraces:
+  enabled: true
+
+SyntaxError:
+  enabled: true
+
+TemplateLength:
+  enabled: true
+  max_length: 200
+
+UnknownFilter:
+  enabled: true
+
+UnusedAssign:
+  enabled: true
+
+UnusedSnippet:
+  enabled: true

--- a/exe/theme-check
+++ b/exe/theme-check
@@ -4,7 +4,7 @@
 require "theme_check"
 
 path = ARGV[0] || "."
-config = ThemeCheck::Config.load_file(path)
+config = ThemeCheck::Config.from_path(path)
 puts "Checking #{config.root} ..."
 theme = ThemeCheck::Theme.new(config.root)
 if theme.all.empty?


### PR DESCRIPTION
Follows a similar approach to robocop, `config/default.yml` contains the default configuration for theme-check and serves as the single source of truth for configuration options (config file validation). 

However following this change, we will need to update the default config file each time we add a new check.

Fixes #3