### PR TITLE
Fix flaky tests & improve offense assertion

### DIFF
--- a/test/checks/convert_include_to_render_test.rb
+++ b/test/checks/convert_include_to_render_test.rb
@@ -9,7 +9,7 @@ class ConvertIncludeToRenderTest < Minitest::Test
         {% include 'templates/foo.liquid' %}
       END
     )
-    assert_equal(<<~END.chomp, offenses.join)
+    assert_offenses(<<~END, offenses)
       `include` is deprecated - convert it to `render` at templates/index.liquid:1
     END
   end
@@ -21,6 +21,6 @@ class ConvertIncludeToRenderTest < Minitest::Test
         {% render 'templates/foo.liquid' %}
       END
     )
-    assert_equal("", offenses.join)
+    assert_offenses("", offenses)
   end
 end

--- a/test/checks/liquid_tag_test.rb
+++ b/test/checks/liquid_tag_test.rb
@@ -14,7 +14,7 @@ class LiquidTagTest < Minitest::Test
         {% endif %}
       END
     )
-    assert_equal(<<~END.chomp, offenses.join)
+    assert_offenses(<<~END, offenses)
       Use {% liquid ... %} to write multiple tags at templates/index.liquid:1
     END
   end
@@ -32,7 +32,7 @@ class LiquidTagTest < Minitest::Test
         {% endif %}
       END
     )
-    assert_equal("", offenses.join)
+    assert_offenses("", offenses)
   end
 
   def test_ignores_inside_liquid_tag
@@ -49,6 +49,6 @@ class LiquidTagTest < Minitest::Test
         %}
       END
     )
-    assert_equal("", offenses.join)
+    assert_offenses("", offenses)
   end
 end

--- a/test/checks/missing_template_test.rb
+++ b/test/checks/missing_template_test.rb
@@ -10,7 +10,7 @@ class MissingTemplateTest < Minitest::Test
         {% render 'two' %}
       END
     )
-    assert_equal(<<~END.chomp, offenses.join("\n"))
+    assert_offenses(<<~END, offenses)
       'snippets/one.liquid' is not found at templates/index.liquid:1
       'snippets/two.liquid' is not found at templates/index.liquid:2
     END
@@ -30,7 +30,7 @@ class MissingTemplateTest < Minitest::Test
         there
       END
     )
-    assert_equal("", offenses.join)
+    assert_offenses("", offenses)
   end
 
   def test_reports_missing_section
@@ -40,7 +40,7 @@ class MissingTemplateTest < Minitest::Test
         {% section 'one' %}
       END
     )
-    assert_equal(<<~END.chomp, offenses.join("\n"))
+    assert_offenses(<<~END, offenses)
       'sections/one.liquid' is not found at templates/index.liquid:1
     END
   end
@@ -55,6 +55,6 @@ class MissingTemplateTest < Minitest::Test
         hey
       END
     )
-    assert_equal("", offenses.join)
+    assert_offenses("", offenses)
   end
 end

--- a/test/checks/nested_snippet_test.rb
+++ b/test/checks/nested_snippet_test.rb
@@ -21,7 +21,7 @@ class NestedSnippetTest < Minitest::Test
         ok
       END
     )
-    assert_equal(<<~END.chomp, offenses.join("\n"))
+    assert_offenses(<<~END, offenses)
       Too many nested snippets at snippets/one.liquid:1
       Too many nested snippets at templates/index.liquid:1
     END
@@ -40,6 +40,6 @@ class NestedSnippetTest < Minitest::Test
         ok
       END
     )
-    assert_equal("", offenses.join)
+    assert_offenses("", offenses)
   end
 end

--- a/test/checks/required_layout_theme_object_test.rb
+++ b/test/checks/required_layout_theme_object_test.rb
@@ -10,7 +10,7 @@ class RequiredLayoutThemeObjectTest < Minitest::Test
       END
     )
 
-    assert_equal("", offenses.join)
+    assert_offenses("", offenses)
   end
 
   def test_picks_up_variable_lookups_only
@@ -24,24 +24,24 @@ class RequiredLayoutThemeObjectTest < Minitest::Test
       END
     )
 
-    assert_equal("", offenses.join)
+    assert_offenses("", offenses)
   end
 
   def test_report_offense_on_missing_content_for_header
     offenses = analyze_layout_theme("{{content_for_layout}}")
 
-    assert_equal(
+    assert_offenses(
       "layout/theme must include {{content_for_header}} at layout/theme.liquid",
-      offenses.join
+      offenses
     )
   end
 
   def test_report_offense_on_missing_content_for_layout
     offenses = analyze_layout_theme("{{content_for_header}}")
 
-    assert_equal(
+    assert_offenses(
       "layout/theme must include {{content_for_layout}} at layout/theme.liquid",
-      offenses.join
+      offenses
     )
   end
 

--- a/test/checks/space_inside_braces_test.rb
+++ b/test/checks/space_inside_braces_test.rb
@@ -11,7 +11,7 @@ class SpaceInsideBracesTest < Minitest::Test
         {{x }}
       END
     )
-    assert_equal(<<~END.chomp, offenses.join("\n"))
+    assert_offenses(<<~END, offenses)
       Space missing before '%}' at templates/index.liquid:1
       Space missing before '}}' at templates/index.liquid:2
       Space missing after '{{' at templates/index.liquid:3
@@ -27,7 +27,7 @@ class SpaceInsideBracesTest < Minitest::Test
         {{ x  }}
       END
     )
-    assert_equal(<<~END.chomp, offenses.join("\n"))
+    assert_offenses(<<~END, offenses)
       Too many spaces after '{{' at templates/index.liquid:1
       Too many spaces before '%}' at templates/index.liquid:2
       Too many spaces before '}}' at templates/index.liquid:3
@@ -42,7 +42,7 @@ class SpaceInsideBracesTest < Minitest::Test
         {% endform %}
       END
     )
-    assert_equal(<<~END.chomp, offenses.join("\n"))
+    assert_offenses(<<~END, offenses)
       Too many spaces after ',' at templates/index.liquid:1
       Space missing after ':' at templates/index.liquid:1
     END

--- a/test/checks/syntax_error_test.rb
+++ b/test/checks/syntax_error_test.rb
@@ -9,7 +9,7 @@ class SyntaxErrorTest < Minitest::Test
         {% include 'muffin'
       END
     )
-    assert_equal(<<~END.chomp, offenses.join)
+    assert_offenses(<<~END, offenses)
       Tag '{%' was not properly terminated with regexp: /\\%\\}/ at templates/index.liquid:1
     END
   end
@@ -21,7 +21,7 @@ class SyntaxErrorTest < Minitest::Test
         {% unknown %}
       END
     )
-    assert_equal(<<~END.chomp, offenses.join)
+    assert_offenses(<<~END, offenses)
       Unknown tag 'unknown' at templates/index.liquid:1
     END
   end
@@ -36,7 +36,7 @@ class SyntaxErrorTest < Minitest::Test
         {% endif %}
       END
     )
-    assert_equal(<<~END.chomp, offenses.join("\n"))
+    assert_offenses(<<~END, offenses)
       Expected end_of_string but found pipe at templates/index.liquid:1
       Expected end_of_string but found pipe at templates/index.liquid:3
     END

--- a/test/checks/template_length_test.rb
+++ b/test/checks/template_length_test.rb
@@ -12,7 +12,7 @@ class TemplateLengthTest < Minitest::Test
         #{"\n" * 9}
       END
     )
-    assert_equal(<<~END.chomp, offenses.join)
+    assert_offenses(<<~END, offenses)
       Template has too many lines [11/10] at templates/long.liquid
     END
   end

--- a/test/checks/unknown_filter_test.rb
+++ b/test/checks/unknown_filter_test.rb
@@ -9,7 +9,7 @@ class UnknownFilterTest < Minitest::Test
         {{ "foo" | bar }}
       END
     )
-    assert_equal(<<~END.chomp, offenses.join)
+    assert_offenses(<<~END, offenses)
       Undefined filter `bar` at templates/index.liquid:1
     END
   end
@@ -21,7 +21,7 @@ class UnknownFilterTest < Minitest::Test
         {{ "foo" | append: ".js" | bar }}
       END
     )
-    assert_equal(<<~END.chomp, offenses.join)
+    assert_offenses(<<~END, offenses)
       Undefined filter `bar` at templates/index.liquid:1
     END
   end
@@ -33,7 +33,7 @@ class UnknownFilterTest < Minitest::Test
         {{ "foo" | upcase }}
       END
     )
-    assert_empty(offenses.join)
+    assert_empty(offenses)
   end
 
   def test_reports_does_not_report_on_chain_of_known_filter
@@ -43,6 +43,6 @@ class UnknownFilterTest < Minitest::Test
         {{ "foo" | append: ".js" | upcase }}
       END
     )
-    assert_empty(offenses.join)
+    assert_empty(offenses)
   end
 end

--- a/test/checks/unused_assign_test.rb
+++ b/test/checks/unused_assign_test.rb
@@ -9,7 +9,7 @@ class UnusedAssignTest < Minitest::Test
         {% assign x = 1 %}
       END
     )
-    assert_equal(<<~END.chomp, offenses.join)
+    assert_offenses(<<~END, offenses)
       `x` is never used at templates/index.liquid:1
     END
   end
@@ -26,7 +26,7 @@ class UnusedAssignTest < Minitest::Test
         {{ 'a' | t: tags: c }}
       END
     )
-    assert_equal("", offenses.join)
+    assert_offenses("", offenses)
   end
 
   def test_do_not_report_assigns_used_before_defined
@@ -38,7 +38,7 @@ class UnusedAssignTest < Minitest::Test
         {% endunless %}
       END
     )
-    assert_equal("", offenses.join)
+    assert_offenses("", offenses)
   end
 
   def test_do_not_report_assigns_used_in_includes
@@ -52,6 +52,6 @@ class UnusedAssignTest < Minitest::Test
         {{ a }}
       END
     )
-    assert_equal("", offenses.join)
+    assert_offenses("", offenses)
   end
 end

--- a/test/checks/unused_snippet_test.rb
+++ b/test/checks/unused_snippet_test.rb
@@ -15,7 +15,7 @@ class UnusedSnippetTest < Minitest::Test
         This is not used
       END
     )
-    assert_equal(<<~END.chomp, offenses.join)
+    assert_offenses(<<~END, offenses)
       This template is not used at snippets/unused.liquid
     END
   end
@@ -34,6 +34,6 @@ class UnusedSnippetTest < Minitest::Test
         This is not used
       END
     )
-    assert_equal("", offenses.join)
+    assert_offenses("", offenses)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,5 +28,9 @@ module Minitest
       at_exit { dir.rmtree }
       ThemeCheck::Theme.new(dir)
     end
+
+    def assert_offenses(output, offenses)
+      assert_equal(output.chomp, offenses.sort_by(&:location).join("\n"))
+    end
   end
 end


### PR DESCRIPTION
`offenses` array was not always in the same order on CI