### PR TITLE
Use absolute path to get filters.yml

### DIFF
--- a/lib/liquid_api.rb
+++ b/lib/liquid_api.rb
@@ -7,7 +7,7 @@ module LiquidAPI
 
     def labels
       @labels ||= begin
-        YAML.load(File.read('data/liquid_api/filters.yml'))
+        YAML.load(File.read("#{__dir__}/../data/liquid_api/filters.yml"))
           .values
           .flatten
       end


### PR DESCRIPTION
Or else doesn't work when running from other directories