### PR TITLE
Add config support for custom check file

### DIFF
--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -89,6 +89,25 @@ class ConfigTest < Minitest::Test
     refute(check_enabled?(config, ThemeCheck::SyntaxError))
   end
 
+  def test_custom_check
+    theme = make_theme(
+      ".theme-check.yml" => <<~END,
+        require:
+          - ./checks/custom_check.rb
+        CustomCheck:
+          enabled: true
+      END
+      "checks/custom_check.rb" => <<~END,
+        module ThemeCheck
+          class CustomCheck
+          end
+        end
+      END
+    )
+    config = ThemeCheck::Config.from_path(theme.root)
+    assert(check_enabled?(config, ThemeCheck::CustomCheck))
+  end
+
   private
 
   def check_enabled?(config, klass)


### PR DESCRIPTION
Part of #31 

This adds support for custom check in a file (instead of gem extension), following a similar syntax to [rubocop](https://docs.rubocop.org/rubocop/extensions.html).

```yml
require:
  - ./path/to/check.rb

MyCustomCheck
  enabled: true
```