### PR TITLE
Force UTF-8 encoding to fix encoding error in VSCode

### DIFF
--- a/exe/liquid-server
+++ b/exe/liquid-server
@@ -6,6 +6,8 @@ require 'liquid_language_server'
 if ENV["LIQUID_LSP_DEBUG"] == "true"
   $DEBUG = true
 end
+# Force encoding to UTF-8 to fix VSCode
+Encoding.default_external = Encoding::UTF_8
 application = LiquidLanguageServer::Application.new
 status_code = application.start
 exit! status_code


### PR DESCRIPTION
Had this issue when testing in VSCode.

```
{"message":"initialized!"}
{"error":"invalid byte sequence in US-ASCII","backtrace":["/Users/ma/.gem/ruby/2.7.1/bundler/gems/liquid-1850511334c5/lib/liquid/tokenizer.rb:31:in `split'","/Users/ma/.gem/ruby/2.7.1/bundler/gems/liqui
```