### PR TITLE
Fix default config not being found when running outside of our repo

### DIFF
--- a/lib/theme_check/config.rb
+++ b/lib/theme_check/config.rb
@@ -4,7 +4,7 @@ module ThemeCheck
   class Config
     DOTFILE = '.theme-check.yml'
     GIT_ROOT = '.git'
-    DEFAULT_CONFIG = 'config/default.yml'
+    DEFAULT_CONFIG = "#{__dir__}/../../config/default.yml"
 
     attr_reader :root
 

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -78,13 +78,17 @@ class ConfigTest < Minitest::Test
   end
 
   def test_enabled_checks_returns_default_checks_for_empty_config
-    YAML.expects(:load_file).with('config/default.yml').returns("SyntaxError" => { "enabled" => true })
+    YAML.expects(:load_file)
+      .with { |path| path.end_with?('config/default.yml') }
+      .returns("SyntaxError" => { "enabled" => true })
     config = ThemeCheck::Config.new(".")
     assert(check_enabled?(config, ThemeCheck::SyntaxError))
   end
 
   def test_config_overrides_default_config
-    YAML.expects(:load_file).with('config/default.yml').returns("SyntaxError" => { "enabled" => true })
+    YAML.expects(:load_file)
+      .with { |path| path.end_with?('config/default.yml') }
+      .returns("SyntaxError" => { "enabled" => true })
     config = ThemeCheck::Config.new(".", "SyntaxError" => { "enabled" => false })
     refute(check_enabled?(config, ThemeCheck::SyntaxError))
   end


### PR DESCRIPTION
Found while testing on project64k.