### PR TITLE
Ensure translation keys exist in main locale file

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -37,3 +37,6 @@ MatchingTranslations:
 
 DefaultLocale:
   enabled: true
+
+TranslationKeyExists:
+  enabled: true

--- a/lib/theme_check/checks/translation_key_exists.rb
+++ b/lib/theme_check/checks/translation_key_exists.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module ThemeCheck
+  class TranslationKeyExists < LiquidCheck
+    severity :error
+
+    def on_variable(node)
+      return unless @theme.default_locale_json&.content&.is_a?(Hash)
+
+      return unless node.value.filters.any? { |name, _| name == "t" || name == "translate" }
+      return unless (key_node = node.children.first)
+      return unless key_node.value.is_a?(String)
+
+      unless key_exists?(key_node.value)
+        add_offense(
+          "'#{key_node.value}' does not have a matching entry in '#{@theme.default_locale_json.relative_path}'",
+          node: node,
+          markup: key_node.value,
+        )
+      end
+    end
+
+    private
+
+    def key_exists?(key)
+      pointer = @theme.default_locale_json.content
+      key.split(".").each do |token|
+        return false unless pointer.key?(token)
+        pointer = pointer[token]
+      end
+
+      true
+    end
+  end
+end

--- a/lib/theme_check/theme.rb
+++ b/lib/theme_check/theme.rb
@@ -18,7 +18,8 @@ module ThemeCheck
     end
 
     def default_locale_json
-      @default_locale_json ||= json.find do |json_file|
+      return @default_locale_json if defined?(@default_locale_json)
+      @default_locale_json = json.find do |json_file|
         json_file.relative_path.to_s.match(%r{locales/.*\.default})
       end
     end

--- a/test/checks/translation_key_exists_test.rb
+++ b/test/checks/translation_key_exists_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class TranslationKeyExistsTest < Minitest::Test
+  def test_noop_without_default_locale
+    offenses = analyze_theme(
+      ThemeCheck::TranslationKeyExists.new,
+      "templates/index.liquid" => <<~END,
+        {{"notfound" | t}}
+      END
+    )
+    assert_offenses("", offenses)
+  end
+
+  def test_noop_with_invalid_default_locale
+    offenses = analyze_theme(
+      ThemeCheck::TranslationKeyExists.new,
+      "locales/en.default.json" => "{",
+      "templates/index.liquid" => <<~END,
+        {{"notfound" | t}}
+      END
+    )
+    assert_offenses("", offenses)
+  end
+
+  def test_ignores_existing_key
+    offenses = analyze_theme(
+      ThemeCheck::TranslationKeyExists.new,
+      "locales/en.default.json" => JSON.dump(
+        key: "",
+        nested: { key: "" }
+      ),
+      "templates/index.liquid" => <<~END,
+        {{"key" | t}}
+        {{"nested.key" | t}}
+      END
+    )
+
+    assert_offenses("", offenses)
+  end
+
+  def test_reports_unknown_key
+    offenses = analyze_theme(
+      ThemeCheck::TranslationKeyExists.new,
+      "locales/en.default.json" => JSON.dump({}),
+      "templates/index.liquid" => <<~END,
+        {{"unknownkey" | t}}
+        {{"unknown.nested.key" | t}}
+        {{"unknownkey" | translate}}
+      END
+    )
+
+    assert_offenses(<<~END, offenses)
+      'unknownkey' does not have a matching entry in 'locales/en.default.json' at templates/index.liquid:1
+      'unknown.nested.key' does not have a matching entry in 'locales/en.default.json' at templates/index.liquid:2
+      'unknownkey' does not have a matching entry in 'locales/en.default.json' at templates/index.liquid:3
+    END
+  end
+end


### PR DESCRIPTION
Implement check that ensures any `{{ STRING_LITERAL | t }}` exist in the default translation file. Part of #17.

The proposed implementation checks for the presence of a `t(ranslate)` filter anywhere in the stack, unlike [`theme-lint`](https://github.com/Shopify/theme-lint/blob/239d40432ad20e50f1e7e90bd618e58cdfe09690/linters/translation_filter_scanner.js#L3). The following wouldn't trigger a check in `theme-lint`, but would here: `{{ "key" | some_filter | t }}`. I'm not sure if that's a bug or a feature 🤔.

I re-used the same copy & pattern as `theme-lint`. This is how it looks:

```
dist/layout/theme.liquid:9: error: TranslationKeyExists: 'nopenope' does not have a matching entry in 'dist/locales/en.default.json'.
	{{ "nopenope" | t }}
	    ^^^^^^^^

dist/layout/theme.liquid:10: error: TranslationKeyExists: 'non.non.non' does not have a matching entry in 'dist/locales/en.default.json'.
	{{ "non.non.non" | translate }}
	    ^^^^^^^^^^^
```
Note: disregard file having `dist` in them, this should be addressed by #53