### PR TITLE
Make Offense#location return nil instead of ""

### DIFF
--- a/lib/theme_check/offense.rb
+++ b/lib/theme_check/offense.rb
@@ -89,7 +89,8 @@ module ThemeCheck
     end
 
     def location
-      [template&.relative_path, line_number].compact.join(":")
+      tokens = [template&.relative_path, line_number].compact
+      tokens.join(":") if tokens.any?
     end
 
     def to_s


### PR DESCRIPTION
This way, the printer can keep on doing `if offense.location`, without
having to check for empty string.

---
I was triggered by this floating colon:

```
Checking ../project-64k ...
: suggestion: DefaultLocale: Default translation file not found (for example locales/en.default.json).
^^ 🙅‍♂️
````

With this PR:
```
Checking ../project-64k ...
suggestion: DefaultLocale: Default translation file not found (for example locales/en.default.json).
^ 😄 
```