### PR TITLE
Add basic check for ensuring all Json files are valid

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -40,3 +40,6 @@ DefaultLocale:
 
 TranslationKeyExists:
   enabled: true
+
+ValidJson:
+  enabled: true

--- a/lib/theme_check/checks/valid_json.rb
+++ b/lib/theme_check/checks/valid_json.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+module ThemeCheck
+  class ValidJson < JsonCheck
+    severity :error
+
+    def on_file(file)
+      if file.parse_error
+        message = file.parse_error.message[/\d+: (.+) at/, 1] || 'Invalid syntax'
+        add_offense("#{message} in JSON", template: file)
+      end
+    end
+  end
+end

--- a/test/checks/valid_json_test.rb
+++ b/test/checks/valid_json_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class ValidJsonTest < Minitest::Test
+  def test_detects_json_error
+    offenses = analyze_theme(
+      ThemeCheck::ValidJson.new,
+      "locales/en.json" => "{",
+    )
+    assert_offenses(<<~END, offenses)
+      unexpected token in JSON at locales/en.json
+    END
+  end
+
+  def test_valid_json
+    offenses = analyze_theme(
+      ThemeCheck::ValidJson.new,
+      "locales/en.json" => "{}",
+    )
+    assert_offenses("", offenses)
+  end
+end


### PR DESCRIPTION
Was wondering why all translation offenses were suddenly gone... I had a syntax error in one of the .json files.