### PR TITLE
Add Required Directories are Present Check

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -58,3 +58,6 @@ MissingRequiredTemplateFiles:
 
 UndefinedObject:
   enabled: true
+
+RequiredDirectories:
+  enabled: true

--- a/lib/theme_check/checks/required_directories.rb
+++ b/lib/theme_check/checks/required_directories.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module ThemeCheck
+  # Reports missing shopify required directories
+
+  class RequiredDirectories < LiquidCheck
+    severity :error
+    category :liquid
+    doc "https://shopify.dev/tutorials/develop-theme-files"
+
+    REQUIRED_DIRECTORIES = %w(assets config layout locales sections snippets templates)
+
+    def on_end
+      directories = theme.directories.map(&:to_s)
+      missing_directories = REQUIRED_DIRECTORIES - directories
+      missing_directories.each { |d| add_missing_directories_offense(d) }
+    end
+
+    private
+
+    def add_missing_directories_offense(directory)
+      add_offense("Theme is missing '#{directory}' directory")
+    end
+  end
+end

--- a/lib/theme_check/theme.rb
+++ b/lib/theme_check/theme.rb
@@ -54,7 +54,7 @@ module ThemeCheck
     end
 
     def directories
-      @directories ||= @root.glob('*').select {|f| File.directory? f}.map { |f| f.relative_path_from(@root) }
+      @directories ||= @root.glob('*').select { |f| File.directory?(f) }.map { |f| f.relative_path_from(@root) }
     end
   end
 end

--- a/test/checks/required_directories_test.rb
+++ b/test/checks/required_directories_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class RequiredDirectories < Minitest::Test
+  def test_does_not_report_missing_directories
+    offenses = analyze_theme(
+      ThemeCheck::RequiredDirectories.new,
+      "assets/gift-card.js" => "",
+      "config/settings_data.json" => "",
+      "layout/theme.liquid" => "",
+      "locales/es.json" => "",
+      "sections/footer.liquid" => "",
+      "snippets/comment.liquid" => "",
+      "templates/index.liquid" => ""
+    )
+
+    assert_empty(offenses)
+  end
+
+  def test_reports_missing_directories
+    offenses = analyze_theme(
+      ThemeCheck::RequiredDirectories.new,
+      "assets/gift-card.js" => "",
+      "config/settings_data.json" => "",
+      "layout/theme.liquid" => "",
+      "sections/footer.liquid" => "",
+      "snippets/comment.liquid" => "",
+      "templates/index.liquid" => ""
+    )
+
+    assert_includes_offense(offenses, "Theme is missing 'locales' directory")
+  end
+end


### PR DESCRIPTION
Check to verify all required directories for the themes are present.
Issue: https://github.com/Shopify/theme-check/issues/74
Reference: https://shopify.dev/tutorials/develop-theme-files

Required directories:
- assets
- config
- layout
- locales
- sections
- snippets
- templates

Also added a method to the themes class to return the directories present, did not use the files to retrieve the directories incase the directories were present but no files were in them.