### PR TITLE
Report on undefined objects

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -57,7 +57,7 @@ MissingRequiredTemplateFiles:
   enabled: true
 
 UndefinedObject:
-  enabled: false
+  enabled: true
 
 RequiredDirectories:
   enabled: true


### PR DESCRIPTION
Report on undefined objects

This started as a check to identify typos in [objects exposed in Shopify
themes](https://shopify.dev/docs/themes/liquid/reference/objects). In
order to accomplish that, I needed to identify all variable definitions
local to the theme and compare the remaining set to the global objects
exposed by Shopify.

Without type checking, theme objects are indiscernible from local variable from the viewpoint
of their lookup. Thus this check reports on all variables, be it locally
defined or exposed by Shopify.

```
snippets/price.liquid:96: error: UndefinedObject: Rendered from snippets/product-card.liquid:87, undefined object `show_badges`.
	{%- if show_badges -%}
	    ^^^^^^^^^^^^^^^

snippets/pagination.liquid:19: error: UndefinedObject: Rendered from templates/search.liquid:106, undefined object `anchor`.
	<a href="{{ paginate.previous.url }}{{ anchor }}" class="pagination__item pagination__item--next button button--text"...
	                                      ^^^^^^^^

snippets/pagination.liquid:28: error: UndefinedObject: Rendered from templates/search.liquid:106, undefined object `anchor`.
	<a href="{{ part.url }}{{ anchor }}" class="pagination__item link link--text" aria-label="{{ 'general.pagination.page...
```