### PR TITLE
Add auto-correct support

### DIFF
--- a/lib/theme_check.rb
+++ b/lib/theme_check.rb
@@ -21,5 +21,6 @@ require_relative "theme_check/tags"
 require_relative "theme_check/template"
 require_relative "theme_check/theme"
 require_relative "theme_check/visitor"
+require_relative "theme_check/corrector"
 
 Dir[__dir__ + "/theme_check/checks/*.rb"].each { |file| require file }

--- a/lib/theme_check/config.rb
+++ b/lib/theme_check/config.rb
@@ -6,7 +6,7 @@ module ThemeCheck
     DEFAULT_CONFIG = "#{__dir__}/../../config/default.yml"
 
     attr_reader :root
-    attr_accessor :only_categories, :exclude_categories
+    attr_accessor :only_categories, :exclude_categories, :auto_correct
 
     class << self
       def from_path(path)
@@ -40,6 +40,7 @@ module ThemeCheck
       end
       @only_categories = []
       @exclude_categories = []
+      @auto_correct = false
       resolve_requires
     end
 

--- a/lib/theme_check/corrector.rb
+++ b/lib/theme_check/corrector.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module ThemeCheck
+  class Corrector
+    def initialize(template:)
+      @template = template
+    end
+
+    def insert_after(node, content)
+      line = @template.full_line(node.line_number)
+      line.insert(node.range[1] + 1, content)
+      @template.update!
+    end
+
+    def insert_before(node, content)
+      line = @template.full_line(node.line_number)
+      line.insert(node.range[0], content)
+      @template.update!
+    end
+
+    def replace(node, content)
+      line = @template.full_line(node.line_number)
+      line[node.range[0]..node.range[1]] = content
+      @template.update!
+    end
+
+    def wrap(node, insert_before, insert_after)
+      line = @template.full_line(node.line_number)
+      line.insert(node.range[0], insert_before)
+      line.insert(node.range[1] + 1 + insert_before.length, insert_after)
+      @template.update!
+    end
+  end
+end

--- a/lib/theme_check/liquid_check.rb
+++ b/lib/theme_check/liquid_check.rb
@@ -6,8 +6,8 @@ module ThemeCheck
     extend ChecksTracking
     include ParsingHelpers
 
-    def add_offense(message, node: nil, template: node&.template, markup: nil, line_number: nil)
-      offenses << Offense.new(check: self, message: message, template: template, node: node, markup: markup, line_number: line_number)
+    def add_offense(message, node: nil, template: node&.template, markup: nil, line_number: nil, &block)
+      offenses << Offense.new(check: self, message: message, template: template, node: node, markup: markup, line_number: line_number, correction: block)
     end
   end
 end

--- a/lib/theme_check/node.rb
+++ b/lib/theme_check/node.rb
@@ -113,5 +113,10 @@ module ThemeCheck
         false
       end
     end
+
+    def range
+      start = template.full_line(line_number).index(markup)
+      [start, start + markup.length - 1]
+    end
   end
 end

--- a/lib/theme_check/printer.rb
+++ b/lib/theme_check/printer.rb
@@ -2,18 +2,26 @@
 
 module ThemeCheck
   class Printer
-    def print(theme, offenses)
+    def print(theme, offenses, auto_correct)
       offenses.each do |offense|
-        print_offense(offense)
+        print_offense(offense, auto_correct)
         puts
       end
 
-      puts "#{theme.all.size} files inspected, #{red(offenses.size.to_s + ' offenses')} detected"
+      correctable = offenses.select(&:correctable?)
+      puts "#{theme.all.size} files inspected, #{red(offenses.size.to_s + ' offenses')} detected, \
+#{yellow(correctable.size.to_s + ' offenses')} #{auto_correct ? 'corrected' : 'auto-correctable'}"
     end
 
-    def print_offense(offense)
+    def print_offense(offense, auto_correct)
       location = if offense.location
         blue(offense.location) + ": "
+      else
+        ""
+      end
+
+      corrected = if auto_correct && offense.correctable?
+        green("[Corrected] ")
       else
         ""
       end
@@ -21,6 +29,7 @@ module ThemeCheck
       puts location +
         colorized_severity(offense.severity) + ": " +
         yellow(offense.check_name) + ": " +
+        corrected +
         offense.message + "."
       if offense.source_excerpt
         puts "\t#{offense.source_excerpt}"

--- a/lib/theme_check/template.rb
+++ b/lib/theme_check/template.rb
@@ -42,6 +42,11 @@ module ThemeCheck
       lines[line - 1].strip
     end
 
+    def source_excerpt(line)
+      original_lines = source.split("\n")
+      original_lines[line - 1].strip
+    end
+
     def full_line(line)
       lines[line - 1]
     end
@@ -56,6 +61,16 @@ module ThemeCheck
 
     def root
       parse.root
+    end
+
+    def update!
+      @updated = true
+    end
+
+    def write
+      if @updated
+        File.write(path, lines.join("\n"))
+      end
     end
 
     def ==(other)

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -58,4 +58,14 @@ class CliTest < Minitest::Test
     end
     assert_includes(out, "LiquidTag:")
   end
+
+  def test_auto_correct
+    cli = ThemeCheck::Cli.new
+    out = capture(:stdout) do
+      assert_raises(ThemeCheck::Cli::Abort) do
+        cli.run([__dir__ + "/theme", "-a"])
+      end
+    end
+    assert_includes(out, "corrected")
+  end
 end

--- a/test/corrector_test.rb
+++ b/test/corrector_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class CorrectorTest < Minitest::Test
+  def setup
+    @theme = make_theme(
+      "templates/index.liquid" => <<~END,
+        <p>
+          {{1 + 2}}
+        </p>
+      END
+    )
+  end
+
+  def test_insert_after_adds_suffix
+    node = stub(
+      template: @theme["templates/index"],
+      line_number: 2,
+      range: [4, 8]
+    )
+    corrector = ThemeCheck::Corrector.new(template: node.template)
+
+    corrector.insert_after(node, " ")
+    assert_equal("{{1 + 2 }}", node.template.excerpt(node.line_number))
+  end
+
+  def test_insert_before_adds_prefix
+    node = stub(
+      template: @theme["templates/index"],
+      line_number: 2,
+      range: [4, 8]
+    )
+    corrector = ThemeCheck::Corrector.new(template: node.template)
+
+    corrector.insert_before(node, " ")
+    assert_equal("{{ 1 + 2}}", node.template.excerpt(node.line_number))
+  end
+
+  def test_replace_replaces_markup
+    node = stub(
+      template: @theme["templates/index"],
+      line_number: 2,
+      range: [4, 8]
+    )
+    corrector = ThemeCheck::Corrector.new(template: node.template)
+
+    corrector.replace(node, "3 + 4")
+    assert_equal("{{3 + 4}}", node.template.excerpt(node.line_number))
+  end
+
+  def test_wrap_adds_prefix_and_suffix
+    node = stub(
+      template: @theme["templates/index"],
+      line_number: 2,
+      range: [4, 8]
+    )
+    corrector = ThemeCheck::Corrector.new(template: node.template)
+
+    corrector.wrap(node, "a", "b")
+    assert_equal("{{a1 + 2b}}", node.template.excerpt(node.line_number))
+  end
+end

--- a/test/offence_test.rb
+++ b/test/offence_test.rb
@@ -44,4 +44,17 @@ class OffenseTest < Minitest::Test
     assert_equal("include 'icon-error'", offense.markup)
     assert_equal(31, offense.markup_start_in_excerpt)
   end
+
+  def test_correct
+    node = stub(
+      template: @theme["templates/index"],
+      line_number: 2,
+      markup: "1 + 2",
+      range: [4, 10]
+    )
+    offense = ThemeCheck::Offense.new(check: Bogus.new, node: node, correction: proc { |c| c.insert_after(node, "abc") })
+    offense.correct
+
+    assert_equal("{{ 1 + 2 abc}}", node.template.excerpt(node.line_number))
+  end
 end


### PR DESCRIPTION
This PR adds a simple auto-correct implementation.

This can be triggered with the new flag `-a`

An example of how a check can add corrections
```ruby
add_offense("Space missing after '{{'", node: node) do |corrector|
  corrector.insert_before(node, " ")
end
```

**TODO**
- [x] Print what offenses were fixed
- [x] Tests

Resolves https://github.com/Shopify/theme-check/issues/57