### PR TITLE
Add corrector to double braces space check

### DIFF
--- a/lib/theme_check/analyzer.rb
+++ b/lib/theme_check/analyzer.rb
@@ -32,7 +32,6 @@ module ThemeCheck
       @theme.json.each { |json_file| @json_checks.call(:on_file, json_file) }
       @liquid_checks.call(:on_end)
       @json_checks.call(:on_end)
-      fix_offenses
       @offenses
     end
 
@@ -50,7 +49,7 @@ module ThemeCheck
       @offenses.select { |offense| !offense.correctable? }
     end
 
-    def fix_offenses
+    def correct_offenses
       if @auto_correct
         @offenses.each(&:correct)
         @theme.liquid.each(&:write)

--- a/lib/theme_check/checks/space_inside_braces.rb
+++ b/lib/theme_check/checks/space_inside_braces.rb
@@ -45,13 +45,24 @@ module ThemeCheck
     def on_variable(node)
       return if @ignore
       if node.markup[0] != " "
-        add_offense("Space missing after '{{'", node: node)
-      elsif node.markup[-1] != " "
-        add_offense("Space missing before '}}'", node: node)
-      elsif node.markup[1] == " "
-        add_offense("Too many spaces after '{{'", node: node)
-      elsif node.markup[-2] == " "
-        add_offense("Too many spaces before '}}'", node: node)
+        add_offense("Space missing after '{{'", node: node) do |corrector|
+          corrector.insert_before(node, " ")
+        end
+      end
+      if node.markup[-1] != " "
+        add_offense("Space missing before '}}'", node: node) do |corrector|
+          corrector.insert_after(node, " ")
+        end
+      end
+      if node.markup[0] == " " && node.markup[1] == " "
+        add_offense("Too many spaces after '{{'", node: node) do |corrector|
+          corrector.replace(node, " #{node.markup.lstrip}")
+        end
+      end
+      if node.markup[-1] == " " && node.markup[-2] == " "
+        add_offense("Too many spaces before '}}'", node: node) do |corrector|
+          corrector.replace(node, "#{node.markup.rstrip} ")
+        end
       end
     end
   end

--- a/lib/theme_check/cli.rb
+++ b/lib/theme_check/cli.rb
@@ -76,6 +76,7 @@ module ThemeCheck
       end
       analyzer = ThemeCheck::Analyzer.new(theme, @config.enabled_checks, @config.auto_correct)
       analyzer.analyze_theme
+      analyzer.correct_offenses
       ThemeCheck::Printer.new.print(theme, analyzer.offenses, @config.auto_correct)
       raise Abort, "" if analyzer.uncorrectable_offenses.any?
     end

--- a/lib/theme_check/corrector.rb
+++ b/lib/theme_check/corrector.rb
@@ -21,6 +21,7 @@ module ThemeCheck
     def replace(node, content)
       line = @template.full_line(node.line_number)
       line[node.range[0]..node.range[1]] = content
+      node.markup = content
       @template.update!
     end
 

--- a/lib/theme_check/node.rb
+++ b/lib/theme_check/node.rb
@@ -22,6 +22,14 @@ module ThemeCheck
       end
     end
 
+    def markup=(markup)
+      if tag?
+        @value.raw = markup
+      elsif @value.instance_variable_defined?(:@markup)
+        @value.instance_variable_set(:@markup, markup)
+      end
+    end
+
     # Array of children nodes.
     def children
       @children ||= begin

--- a/lib/theme_check/template.rb
+++ b/lib/theme_check/template.rb
@@ -8,6 +8,7 @@ module ThemeCheck
     def initialize(path, root)
       @path = Pathname(path)
       @root = Pathname(root)
+      @updated = false
     end
 
     def relative_path
@@ -35,7 +36,8 @@ module ThemeCheck
     end
 
     def lines
-      @lines ||= source.split("\n")
+      # Retain trailing newline character
+      @lines ||= source.split("\n", -1)
     end
 
     def excerpt(line)
@@ -69,7 +71,7 @@ module ThemeCheck
 
     def write
       if @updated
-        File.write(path, lines.join("\n"))
+        @path.write(lines.join("\n"))
       end
     end
 

--- a/test/checks/space_inside_braces_test.rb
+++ b/test/checks/space_inside_braces_test.rb
@@ -74,4 +74,42 @@ class SpaceInsideBracesTest < Minitest::Test
     )
     assert_equal("", offenses.join("\n"))
   end
+
+  def test_corrects_missing_space
+    expected_sources = {
+      "templates/index.liquid" => <<~END,
+        {{ x }}
+        {{ x }}
+      END
+    }
+    sources = fix_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {{ x}}
+        {{x }}
+      END
+    )
+    sources.each do |path, source|
+      assert_equal(source, expected_sources[path])
+    end
+  end
+
+  def test_corrects_extra_space
+    expected_sources = {
+      "templates/index.liquid" => <<~END,
+        {{ x }}
+        {{ x }}
+      END
+    }
+    sources = fix_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {{ x  }}
+        {{  x }}
+      END
+    )
+    sources.each do |path, source|
+      assert_equal(source, expected_sources[path])
+    end
+  end
 end

--- a/test/corrector_test.rb
+++ b/test/corrector_test.rb
@@ -40,7 +40,8 @@ class CorrectorTest < Minitest::Test
     node = stub(
       template: @theme["templates/index"],
       line_number: 2,
-      range: [4, 8]
+      range: [4, 8],
+      :markup= => ()
     )
     corrector = ThemeCheck::Corrector.new(template: node.template)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,6 +30,15 @@ module Minitest
       ThemeCheck::Theme.new(dir)
     end
 
+    def fix_theme(*check_classes, templates)
+      theme = make_theme(templates)
+      analyzer = ThemeCheck::Analyzer.new(theme, check_classes, true)
+      analyzer.analyze_theme
+      analyzer.correct_offenses
+      sources = theme.liquid.map { |template| [template.relative_path.to_s, template.path.read] }
+      Hash[*sources.flatten]
+    end
+
     def assert_offenses(output, offenses)
       assert_equal(output.chomp, offenses.sort_by(&:location).join("\n"))
     end


### PR DESCRIPTION
Adds corrector to the double braces space checks so that they can be auto-corrected. Added also a fix to `corrector.rb` to update a node's markup on replace.

I'm hesitant to add the corrector to space check for liquid tags because we are able to check for missing or extra spaces before the closing brace but not after the opening brace.