### PR TITLE
Extend UndefinedObject check with alias

### DIFF
--- a/lib/theme_check/checks/undefined_object.rb
+++ b/lib/theme_check/checks/undefined_object.rb
@@ -121,7 +121,8 @@ module ThemeCheck
         snippet_info = @files[snippet_name]
         next unless snippet_info # NOTE: undefined snippet
 
-        snippet_variables = node.value.attributes.keys
+        snippet_variables = node.value.attributes.keys +
+          Array[node.value.instance_variable_get("@alias_name")]
         check_object(snippet_info, all_global_objects + snippet_variables, node)
       end
     end

--- a/test/checks/undefined_object_test.rb
+++ b/test/checks/undefined_object_test.rb
@@ -118,6 +118,34 @@ class UndefinedObjectTest < Minitest::Test
     assert_offenses("", offenses)
   end
 
+  def test_does_not_report_on_render_using_the_with_parameter
+    offenses = analyze_theme(
+      ThemeCheck::UndefinedObject.new,
+      "templates/index.liquid" => <<~END,
+        {% assign featured_product = all_products['product_handle'] %}
+        {% render 'product' with featured_product as my_product %}
+      END
+      "snippets/product.liquid" => <<~END,
+        {{ my_product.available }}
+      END
+    )
+    assert_offenses("", offenses)
+  end
+
+  def test_does_not_report_on_render_using_the_for_parameter
+    offenses = analyze_theme(
+      ThemeCheck::UndefinedObject.new,
+      "templates/index.liquid" => <<~END,
+        {% assign variants = product.variants %}
+        {% render 'variant' for variants as my_variant %}
+      END
+      "snippets/variant.liquid" => <<~END,
+        {{ my_variant.price }}
+      END
+    )
+    assert_offenses("", offenses)
+  end
+
   def test_report_on_render_with_variable_from_parent_context
     offenses = analyze_theme(
       ThemeCheck::UndefinedObject.new,


### PR DESCRIPTION
The render tag supports a syntax using a 'with' parameter as well as a 'for' parameter: https://shopify.dev/docs/themes/liquid/reference/tags/theme-tags\#render. This commit extends the check to understand any alias passed as argument.