### PR TITLE
Check for deprecated filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Theme Check currently checks for the following:
 ✅ Using unknown translation keys in `{{ 'missing_key' | t }}`  
 ✅ Using several `{% ... %}` instead of `{% liquid ... %}`  
 ✅ Undefined [objects](https://shopify.dev/docs/themes/liquid/reference/objects)
+✅ Deprecated filters  
 
 And many more to come! Suggestions welcome ([create an issue](https://github.com/Shopify/theme-check/issues)).
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -61,3 +61,6 @@ UndefinedObject:
 
 RequiredDirectories:
   enabled: true
+
+DeprecatedFilter:
+  enabled: true

--- a/data/shopify_liquid/deprecated_filters.yml
+++ b/data/shopify_liquid/deprecated_filters.yml
@@ -1,0 +1,10 @@
+---
+Liquid::ColorFilter:
+  hex_to_rgba:
+    - color_to_rgb
+    - color_modify
+Liquid::UrlFilter:
+  collection_img_url:
+    - img_url
+  product_img_url:
+    - img_url

--- a/lib/theme_check/checks/deprecated_filter.rb
+++ b/lib/theme_check/checks/deprecated_filter.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module ThemeCheck
+  class DeprecatedFilter < LiquidCheck
+    doc "https://shopify.dev/docs/themes/liquid/reference/filters/deprecated-filters"
+    category :liquid
+    severity :suggestion
+
+    def on_variable(node)
+      used_filters = node.value.filters.map { |name, *_rest| name }
+      used_filters.each do |filter|
+        alternatives = ShopifyLiquid::DeprecatedFilter.alternatives(filter)
+        next unless alternatives
+
+        alternatives = alternatives.map { |alt| "`#{alt}`" }
+        add_offense(
+          "Deprecated filter `#{filter}`, consider using an alternative: #{alternatives.join(', ')}",
+          node: node,
+        )
+      end
+    end
+  end
+end

--- a/lib/theme_check/shopify_liquid.rb
+++ b/lib/theme_check/shopify_liquid.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+require_relative 'shopify_liquid/deprecated_filter'
 require_relative 'shopify_liquid/filter'
 require_relative 'shopify_liquid/object'

--- a/lib/theme_check/shopify_liquid/deprecated_filter.rb
+++ b/lib/theme_check/shopify_liquid/deprecated_filter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'yaml'
+
+module ThemeCheck
+  module ShopifyLiquid
+    module DeprecatedFilter
+      extend self
+
+      def alternatives(filter)
+        all.fetch(filter, nil)
+      end
+
+      private
+
+      def all
+        @all ||= begin
+          YAML.load(File.read("#{__dir__}/../../../data/shopify_liquid/deprecated_filters.yml"))
+            .values
+            .each_with_object({}) do |filters, acc|
+              filters.each do |(filter, alternatives)|
+                acc[filter] = alternatives
+              end
+            end
+        end
+      end
+    end
+  end
+end

--- a/test/checks/deprecated_filter_test.rb
+++ b/test/checks/deprecated_filter_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class DeprecatedFilterTest < Minitest::Test
+  def test_reports_on_deprecate_filter
+    offenses = analyze_theme(
+      ThemeCheck::DeprecatedFilter.new,
+      "templates/index.liquid" => <<~END,
+        color: {{ settings.color_name | hex_to_rgba: 0.5 }};
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Deprecated filter `hex_to_rgba`, consider using an alternative: `color_to_rgb`, `color_modify` at templates/index.liquid:1
+    END
+  end
+
+  def test_does_not_report_on_filter
+    offenses = analyze_theme(
+      ThemeCheck::DeprecatedFilter.new,
+      "templates/index.liquid" => <<~END,
+        color: {{ '#7ab55c' | color_to_rgb }};
+      END
+    )
+    assert_offenses("", offenses)
+  end
+end

--- a/test/shopify_liquid_test.rb
+++ b/test/shopify_liquid_test.rb
@@ -2,6 +2,15 @@
 require "test_helper"
 
 class ShopifyLiquidTest < Minitest::Test
+  def test_deprecated_filter_alternatives
+    assert_equal(
+      ['color_to_rgb', 'color_modify'].sort,
+      ThemeCheck::ShopifyLiquid::DeprecatedFilter.alternatives('hex_to_rgba').sort,
+    )
+
+    assert_nil(ThemeCheck::ShopifyLiquid::DeprecatedFilter.alternatives('color_to_rgb'))
+  end
+
   def test_filter_labels
     assert_equal(151, ThemeCheck::ShopifyLiquid::Filter.labels.size)
   end


### PR DESCRIPTION
Implements https://github.com/Shopify/theme-check/issues/8

I chose to write a new filter, instead of extending the UndefinedFilter, because deprecated filters continue to work to support existing themes. Those filters are no longer supported. Additionally, I wanted to make this check return a severity of type suggestion.