### PR TITLE
Fix error when Offense#end_line is called on multiline markup

### DIFF
--- a/lib/theme_check/offense.rb
+++ b/lib/theme_check/offense.rb
@@ -55,18 +55,22 @@ module ThemeCheck
     end
 
     def end_line
-      return 0 unless line_number
-      line_number - 1
+      if markup
+        start_line + markup.count("\n")
+      else
+        start_line
+      end
     end
 
     def start_column
-      return 0 unless line_number
-      template.full_line(line_number).index(markup)
+      return 0 unless line_number && markup
+      template.full_line(start_line + 1).index(markup.split("\n", 2).first)
     end
 
     def end_column
-      return 0 unless line_number
-      template.full_line(line_number).index(markup) + markup.size
+      return 0 unless line_number && markup
+      markup_end = markup.split("\n").last
+      template.full_line(end_line + 1).index(markup_end) + markup_end.size
     end
 
     def code_name

--- a/test/offence_test.rb
+++ b/test/offence_test.rb
@@ -12,6 +12,12 @@ class OffenseTest < Minitest::Test
       "templates/long.liquid" => <<~END,
         <span class="form__message">{% include 'icon-error' %}{{ form.errors.translated_fields['email'] | capitalize }} {{ form.errors.messages['email'] }}.</span>
       END
+      "templates/multiline.liquid" => <<~END,
+        {% render 'product-card',
+          product: product,
+          show: true
+        %}
+      END
     )
   end
 
@@ -56,5 +62,44 @@ class OffenseTest < Minitest::Test
     offense.correct
 
     assert_equal("{{ 1 + 2 abc}}", node.template.excerpt(node.line_number))
+  end
+
+  def test_location
+    node = stub(
+      template: @theme["templates/index"],
+      line_number: 2,
+      markup: "1 + 2",
+    )
+    offense = ThemeCheck::Offense.new(check: Bogus.new, node: node)
+    assert_equal(1, offense.start_line)
+    assert_equal(1, offense.end_line)
+    assert_equal(5, offense.start_column)
+    assert_equal(10, offense.end_column)
+  end
+
+  def test_multiline_markup_location
+    node = stub(
+      template: @theme["templates/multiline"],
+      line_number: 1,
+      markup: "render 'product-card',\n  product: product,\n  show: true",
+    )
+    offense = ThemeCheck::Offense.new(check: Bogus.new, node: node)
+    assert_equal(0, offense.start_line)
+    assert_equal(2, offense.end_line)
+    assert_equal(3, offense.start_column)
+    assert_equal(12, offense.end_column)
+  end
+
+  def test_location_without_markup
+    node = stub(
+      template: @theme["templates/index"],
+      line_number: 1,
+      markup: nil,
+    )
+    offense = ThemeCheck::Offense.new(check: Bogus.new, node: node)
+    assert_equal(0, offense.start_line)
+    assert_equal(0, offense.end_line)
+    assert_equal(0, offense.start_column)
+    assert_equal(0, offense.end_column)
   end
 end


### PR DESCRIPTION
Caused an exception in vscode plugin when encountering markup like:

```
          {% render 'product-card',
            product_card_product: product,
            show_vendor: section.settings.show_vendor,
            media_size: section.settings.product_image_ratio,
            center_align_text: section.settings.center_align_text,
            show_full_details: true
          %}
```

Because of the multiline, the markup is not found in the `template.full_line(...)`