### PR TITLE
Fixup end_column bug when index returns nil

### DIFF
--- a/lib/theme_check/offense.rb
+++ b/lib/theme_check/offense.rb
@@ -61,12 +61,12 @@ module ThemeCheck
 
     def start_column
       return 0 unless line_number
-      template.full_line(line_number).index(markup)
+      template.full_line(line_number).index(markup) || 0
     end
 
     def end_column
       return 0 unless line_number
-      template.full_line(line_number).index(markup) + markup.size
+      start_column + markup.size
     end
 
     def code_name


### PR DESCRIPTION
When using the VSCode extension with the latest version, I was running into errors when linting:

```
Found 579 templates, and 101 offenses
undefined method `+' for nil:NilClass
/Users/charles/src/github.com/Shopify/theme-check/lib/theme_check/offense.rb:69:in `end_column'
/Users/charles/src/github.com/Shopify/theme-check/lib/theme_check/language_server/handler.rb:98:in `range'
/Users/charles/src/github.com/Shopify/theme-check/lib/theme_check/language_server/handler.rb:69:in `offense_to_diagnostic'
/Users/charles/src/github.com/Shopify/theme-check/lib/theme_check/language_server/handler.rb:61:in `block (2 levels) in send_offenses'
/Users/charles/src/github.com/Shopify/theme-check/lib/theme_check/language_server/handler.rb:61:in `map'
/Users/charles/src/github.com/Shopify/theme-check/lib/theme_check/language_server/handler.rb:61:in `block in send_offenses'
/Users/charles/src/github.com/Shopify/theme-check/lib/theme_check/language_server/handler.rb:54:in `each'
/Users/charles/src/github.com/Shopify/theme-check/lib/theme_check/language_server/handler.rb:54:in `send_offenses'
/Users/charles/src/github.com/Shopify/theme-check/lib/theme_check/language_server/handler.rb:50:in `analyze_and_send_offenses'
/Users/charles/src/github.com/Shopify/theme-check/lib/theme_check/language_server/handler.rb:35:in `on_text_document_did_open'
/Users/charles/src/github.com/Shopify/theme-check/lib/theme_check/language_server/server.rb:89:in `process_request'
/Users/charles/src/github.com/Shopify/theme-check/lib/theme_check/language_server/server.rb:30:in `block in listen'
/Users/charles/src/github.com/Shopify/theme-check/lib/theme_check/language_server/server.rb:29:in `loop'
/Users/charles/src/github.com/Shopify/theme-check/lib/theme_check/language_server/server.rb:29:in `listen'
/Users/charles/src/github.com/Shopify/theme-check/lib/theme_check/language_server.rb:8:in `start'
/Users/charles/src/github.com/Shopify/theme-check/exe/theme-check-language-server:11:in `<top (required)>'
/Users/charles/.gem/ruby/2.7.1/bin/theme-check-language-server:23:in `load'
/Users/charles/.gem/ruby/2.7.1/bin/theme-check-language-server:23:in `<top (required)>'
/Users/charles/.gem/ruby/2.7.1/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `load'
/Users/charles/.gem/ruby/2.7.1/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `kernel_load'
/Users/charles/.gem/ruby/2.7.1/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:28:in `run'
/Users/charles/.gem/ruby/2.7.1/gems/bundler-2.1.4/lib/bundler/cli.rb:476:in `exec'
/Users/charles/.gem/ruby/2.7.1/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/charles/.gem/ruby/2.7.1/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/Users/charles/.gem/ruby/2.7.1/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
/Users/charles/.gem/ruby/2.7.1/gems/bundler-2.1.4/lib/bundler/cli.rb:30:in `dispatch'
/Users/charles/.gem/ruby/2.7.1/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
/Users/charles/.gem/ruby/2.7.1/gems/bundler-2.1.4/lib/bundler/cli.rb:24:in `start'
/Users/charles/.gem/ruby/2.7.1/gems/bundler-2.1.4/exe/bundle:46:in `block in <top (required)>'
/Users/charles/.gem/ruby/2.7.1/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
/Users/charles/.gem/ruby/2.7.1/gems/bundler-2.1.4/exe/bundle:34:in `<top (required)>'
/Users/charles/.gem/ruby/2.7.1/bin/bundle:23:in `load'
/Users/charles/.gem/ruby/2.7.1/bin/bundle:23:in `<main>'
```

Looks like this happens when we can't find the markup on the line of the error. Adding a basic null check but that might not be the entire story.