### PR TITLE
Add Ruby 2.7 as a gem requirement

### DIFF
--- a/theme-check.gemspec
+++ b/theme-check.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/Shopify/theme-check"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = ">= 2.7"
+
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
   spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do


### PR DESCRIPTION
To avoid confusing errors such as #118