### PR TITLE
Adding checks for shopify plus objects in checkout

### DIFF
--- a/data/shopify_liquid/plus_objects.yml
+++ b/data/shopify_liquid/plus_objects.yml
@@ -1,0 +1,15 @@
+---
+- alternative_payment_methods
+- breadcrumb
+- checkout_html_classes
+- checkout_scripts
+- checkout_stylesheets
+- content_for_footer
+- content_for_logo
+- content_for_order_summary
+- direction
+- locale
+- order_summary_toggle
+- page_title
+- skip_to_content_link
+- tracking_code

--- a/lib/theme_check/checks/undefined_object.rb
+++ b/lib/theme_check/checks/undefined_object.rb
@@ -95,11 +95,19 @@ module ThemeCheck
       all_global_objects = ThemeCheck::ShopifyLiquid::Object.labels
       all_global_objects.freeze
 
+      shopify_plus_objects = ThemeCheck::ShopifyLiquid::Object.plus_labels
+      shopify_plus_objects.freeze
+
       each_template do |(name, info)|
         if 'templates/customers/reset_password' == name
           # NOTE: `email` is exceptionally exposed as a theme object in
           #       the customers' reset password template
           check_object(info, all_global_objects + ['email'])
+        elsif 'layout/checkout' == name
+          # NOTE: Shopify Plus has exceptionally exposed objects in
+          #       the checkout template
+          # https://shopify.dev/docs/themes/theme-templates/checkout-liquid#optional-objects
+          check_object(info, all_global_objects + shopify_plus_objects)
         else
           check_object(info, all_global_objects)
         end

--- a/lib/theme_check/shopify_liquid/object.rb
+++ b/lib/theme_check/shopify_liquid/object.rb
@@ -11,6 +11,12 @@ module ThemeCheck
           YAML.load(File.read("#{__dir__}/../../../data/shopify_liquid/objects.yml"))
         end
       end
+
+      def plus_labels
+        @plus_labels ||= begin
+          YAML.load(File.read("#{__dir__}/../../../data/shopify_liquid/plus_objects.yml"))
+        end
+      end
     end
   end
 end

--- a/test/checks/undefined_object_test.rb
+++ b/test/checks/undefined_object_test.rb
@@ -316,4 +316,26 @@ class UndefinedObjectTest < Minitest::Test
       Undefined object `email` at templates/index.liquid:1
     END
   end
+
+  def test_does_not_report_on_shopify_plus_objects_in_checkout
+    offenses = analyze_theme(
+      ThemeCheck::UndefinedObject.new,
+      "layout/checkout.liquid" => <<~END,
+        <p>{{ checkout_html_classes }}</p>
+      END
+    )
+    assert_offenses("", offenses)
+  end
+
+  def test_reports_on_shopify_plus_objects_other_than_checkout
+    offenses = analyze_theme(
+      ThemeCheck::UndefinedObject.new,
+      "templates/index.liquid" => <<~END,
+        <p>{{ checkout_html_classes }}</p>
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Undefined object `checkout_html_classes` at templates/index.liquid:1
+    END
+  end
 end


### PR DESCRIPTION
Making an update to allow for additional, optional objects in the checkout.liquid file.

Based off objects listed in Docs: https://shopify.dev/docs/themes/theme-templates/checkout-liquid#optional-objects