### PR TITLE
Ignore node on assign type 

### DIFF
--- a/lib/theme_check/checks/space_inside_braces.rb
+++ b/lib/theme_check/checks/space_inside_braces.rb
@@ -11,6 +11,7 @@ module ThemeCheck
 
     def on_node(node)
       return unless node.markup
+      return if :assign == node.type_name
 
       outside_of_strings(node.markup) do |chunk|
         chunk.scan(/([,:])  +/) do |_match|

--- a/test/checks/space_inside_braces_test.rb
+++ b/test/checks/space_inside_braces_test.rb
@@ -48,6 +48,18 @@ class SpaceInsideBracesTest < Minitest::Test
     END
   end
 
+  def test_reports_extra_space_after_colon_in_assign_tag
+    offenses = analyze_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {% assign max_width = height | times:  image.aspect_ratio %}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Too many spaces after ':' at templates/index.liquid:1
+    END
+  end
+
   def test_dont_report_with_proper_spaces
     offenses = analyze_theme(
       ThemeCheck::SpaceInsideBraces.new,


### PR DESCRIPTION
Came across an issue with Space checking between `,:` characters while adding `|`
On an assign tag the check returns the error twice as seen below
since the assign node markup returns the whole content including the variable

assign node markup : `assign max_width = height | times:  image.aspect_ratio`
variable node markup: `height | times:  image.aspect_ratio`

error thrown
```
+"Too many spaces after ':' at templates/index.liquid:1
+Too many spaces after ':' at templates/index.liquid:1"
```

This pr ignores the check if node type is `assign`;