### PR TITLE
Revert "Add Ruby 2.7 as a gem requirement"

### DIFF
--- a/theme-check.gemspec
+++ b/theme-check.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/Shopify/theme-check"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.7"
-
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
   spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do


### PR DESCRIPTION
Reverts Shopify/theme-check#120

Shipit doesn't support Ruby 2.7. Revert this requirement for now as we need to push the fix for vscode.