### PR TITLE
Add config to ignore files / directories

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3,7 +3,7 @@ root: .
 require: []
 
 ignore:
-  - node_modules
+  - node_modules/*
 
 ConvertIncludeToRender:
   enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,10 @@
+root: .
+
+require: []
+
+ignore:
+  - node_modules
+
 ConvertIncludeToRender:
   enabled: true
 

--- a/lib/theme_check/cli.rb
+++ b/lib/theme_check/cli.rb
@@ -70,7 +70,7 @@ module ThemeCheck
 
     def check
       puts "Checking #{@config.root} ..."
-      theme = ThemeCheck::Theme.new(@config.root)
+      theme = ThemeCheck::Theme.new(@config.root, ignored_patterns: @config.ignored_patterns)
       if theme.all.empty?
         raise Abort, "No templates found.\n#{USAGE}"
       end

--- a/lib/theme_check/language_server/handler.rb
+++ b/lib/theme_check/language_server/handler.rb
@@ -41,7 +41,7 @@ module ThemeCheck
       def analyze_and_send_offenses(file_path)
         root = ThemeCheck::Config.find(file_path) || @root_path
         config = ThemeCheck::Config.from_path(root)
-        theme = ThemeCheck::Theme.new(config.root)
+        theme = ThemeCheck::Theme.new(config.root, ignored_patterns: config.ignored_patterns)
         analyzer = ThemeCheck::Analyzer.new(theme, config.enabled_checks)
 
         log("Checking #{config.root}")

--- a/test/theme_test.rb
+++ b/test/theme_test.rb
@@ -47,4 +47,20 @@ class ThemeTest < Minitest::Test
   def test_default_locale
     assert_equal("en", @theme.default_locale)
   end
+
+  def test_ignore
+    theme = ThemeCheck::Theme.new(make_theme(
+      "templates/index.liquid" => "",
+      "ignored/product.liquid" => "",
+      "ignored/nested/product.liquid" => "",
+      "locales/en.default.json" => "",
+      "locales/nested/en.default.json" => "",
+    ).root, ignored_patterns: [
+      "ignored/*",
+      "*.json",
+    ])
+
+    assert_equal([], theme.json.map(&:name))
+    assert_equal(["templates/index"], theme.liquid.map(&:name))
+  end
 end


### PR DESCRIPTION
In `.theme-check.yml`
```
ignore:
  - node_modules/*
  - docs/*.json
```

Will ignore all files matching any of those patterns (matched using [`fnmatch`](https://ruby-doc.org/core-2.5.0/File.html#method-c-fnmatch)).

Defaults to `["node_modules/*"]`.

Fixes #128 

I also added a bit more validation to `Config`:
- Check for type, by comparing to default
- Check for unknown configs, by comparing to default
- Ignore custom checks, but validate its config is a Hash