### PR TITLE
Add Position Arg to Offense

### DIFF
--- a/lib/theme_check/liquid_check.rb
+++ b/lib/theme_check/liquid_check.rb
@@ -6,8 +6,8 @@ module ThemeCheck
     extend ChecksTracking
     include ParsingHelpers
 
-    def add_offense(message, node: nil, template: node&.template, markup: nil, line_number: nil, &block)
-      offenses << Offense.new(check: self, message: message, template: template, node: node, markup: markup, line_number: line_number, correction: block)
+    def add_offense(message, node: nil, template: node&.template, markup: nil, line_number: nil, position: nil, &block)
+      offenses << Offense.new(check: self, message: message, template: template, node: node, markup: markup, line_number: line_number, position: position, correction: block)
     end
   end
 end

--- a/lib/theme_check/offense.rb
+++ b/lib/theme_check/offense.rb
@@ -3,9 +3,9 @@ module ThemeCheck
   class Offense
     MAX_SOURCE_EXCERPT_SIZE = 120
 
-    attr_reader :check, :message, :template, :node, :markup, :line_number, :correction
+    attr_reader :check, :message, :template, :node, :markup, :line_number, :position, :correction
 
-    def initialize(check:, message: nil, template: nil, node: nil, markup: nil, line_number: nil, correction: nil)
+    def initialize(check:, message: nil, template: nil, node: nil, markup: nil, line_number: nil, position: nil, correction: nil)
       @check = check
       @correction = correction
 
@@ -35,6 +35,8 @@ module ThemeCheck
       elsif @node
         @node.line_number
       end
+
+      @position = position
     end
 
     def source_excerpt
@@ -63,11 +65,13 @@ module ThemeCheck
     end
 
     def start_column
+      return position if position
       return 0 unless line_number && markup
       template.full_line(start_line + 1).index(markup.split("\n", 2).first)
     end
 
     def end_column
+      return position + markup.size if position
       return 0 unless line_number && markup
       markup_end = markup.split("\n").last
       template.full_line(end_line + 1).index(markup_end) + markup_end.size

--- a/test/offence_test.rb
+++ b/test/offence_test.rb
@@ -9,6 +9,11 @@ class OffenseTest < Minitest::Test
           {{ 1 + 2 }}
         </p>
       END
+      "templates/repeated.liquid" => <<~END,
+        <p>
+          {{ render 'something',  arg1,  arg2 }}
+        </p>
+      END
       "templates/long.liquid" => <<~END,
         <span class="form__message">{% include 'icon-error' %}{{ form.errors.translated_fields['email'] | capitalize }} {{ form.errors.messages['email'] }}.</span>
       END
@@ -75,6 +80,19 @@ class OffenseTest < Minitest::Test
     assert_equal(1, offense.end_line)
     assert_equal(5, offense.start_column)
     assert_equal(10, offense.end_column)
+  end
+
+  def test_location_with_postion
+    node = stub(
+      template: @theme["templates/repeated"],
+      line_number: 2,
+      markup: ",  ",
+    )
+    offense = ThemeCheck::Offense.new(check: Bogus.new, node: node, position: 31)
+    assert_equal(1, offense.start_line)
+    assert_equal(1, offense.end_line)
+    assert_equal(31, offense.start_column)
+    assert_equal(34, offense.end_column)
   end
 
   def test_multiline_markup_location


### PR DESCRIPTION
PR to add position argument to offence.

Currently relying on `.index` to find the markup place, with that the existence of multiple of the same errors would all just fall on the first occurrence of the error as shown.

<img width="574" alt="Screen Shot 2021-02-02 at 9 53 21 AM" src="https://user-images.githubusercontent.com/25163405/106617295-7d538200-653c-11eb-8b3f-72f04fb35c71.png">

