### PR TITLE
Fix VSCode problems not clearing problems when file is deleted

### DIFF
--- a/lib/theme_check/language_server/server.rb
+++ b/lib/theme_check/language_server/server.rb
@@ -9,6 +9,8 @@ module ThemeCheck
     class IncompatibleStream < StandardError; end
 
     class Server
+      attr_reader :handler
+
       def initialize(
         in_stream: STDIN,
         out_stream: STDOUT,

--- a/lib/theme_check/language_server/server.rb
+++ b/lib/theme_check/language_server/server.rb
@@ -87,8 +87,6 @@ module ThemeCheck
 
         if @handler.respond_to?(method_name)
           @handler.send(method_name, id, params)
-        else
-          log("Handler does not respond to #{method_name}")
         end
       end
 


### PR DESCRIPTION
Fixes #136 

Switch approach from reporting diagnostic for every templates currently on disk, to only reporting the ones reported previously.

Should report less diagnostics, and handle file deletion.
