### PR TITLE
Ignore snippets in UndefinedObject

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
   TargetRubyVersion: 2.7
   Exclude:
     - 'vendor/bundle/**/*'
+    - 'packaging/builds/**/*'
 
 Metrics/MethodLength:
   Enabled: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -67,7 +67,7 @@ MissingRequiredTemplateFiles:
 
 UndefinedObject:
   enabled: true
-  ignore_snippets: true
+  exclude_snippets: true
 
 RequiredDirectories:
   enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -67,6 +67,7 @@ MissingRequiredTemplateFiles:
 
 UndefinedObject:
   enabled: true
+  ignore_snippets: true
 
 RequiredDirectories:
   enabled: true

--- a/lib/theme_check/checks/undefined_object.rb
+++ b/lib/theme_check/checks/undefined_object.rb
@@ -49,23 +49,28 @@ module ThemeCheck
       end
     end
 
-    def initialize
+    def initialize(ignore_snippets: false)
+      @ignore_snippets = ignore_snippets
       @files = {}
     end
 
     def on_document(node)
+      return if ignore?(node)
       @files[node.template.name] = TemplateInfo.new
     end
 
     def on_assign(node)
+      return if ignore?(node)
       @files[node.template.name].all_assigns[node.value.to] = node
     end
 
     def on_capture(node)
+      return if ignore?(node)
       @files[node.template.name].all_captures[node.value.instance_variable_get('@to')] = node
     end
 
     def on_for(node)
+      return if ignore?(node)
       @files[node.template.name].all_forloops[node.value.variable_name] = node
     end
 
@@ -75,6 +80,7 @@ module ThemeCheck
     end
 
     def on_render(node)
+      return if ignore?(node)
       return unless node.value.template_name_expr.is_a?(String)
 
       snippet_name = "snippets/#{node.value.template_name_expr}"
@@ -85,6 +91,7 @@ module ThemeCheck
     end
 
     def on_variable_lookup(node)
+      return if ignore?(node)
       @files[node.template.name].add_variable_lookup(
         name: node.value.name,
         node: node,
@@ -114,13 +121,18 @@ module ThemeCheck
       end
     end
 
+    private
+
+    def ignore?(node)
+      @ignore_snippets && node.template.snippet?
+    end
+
     def each_template
       @files.each do |(name, info)|
         next if name.starts_with?('snippets/')
         yield [name, info]
       end
     end
-    private :each_template
 
     def check_object(info, all_global_objects, render_node = nil)
       check_undefined(info, all_global_objects, render_node)
@@ -134,7 +146,6 @@ module ThemeCheck
         check_object(snippet_info, all_global_objects + snippet_variables, node)
       end
     end
-    private :check_object
 
     def check_undefined(info, all_global_objects, render_node)
       all_variables = info.all_variables
@@ -154,6 +165,5 @@ module ThemeCheck
         end
       end
     end
-    private :check_undefined
   end
 end

--- a/lib/theme_check/checks/undefined_object.rb
+++ b/lib/theme_check/checks/undefined_object.rb
@@ -49,8 +49,8 @@ module ThemeCheck
       end
     end
 
-    def initialize(ignore_snippets: false)
-      @ignore_snippets = ignore_snippets
+    def initialize(exclude_snippets: false)
+      @exclude_snippets = exclude_snippets
       @files = {}
     end
 
@@ -124,7 +124,7 @@ module ThemeCheck
     private
 
     def ignore?(node)
-      @ignore_snippets && node.template.snippet?
+      @exclude_snippets && node.template.snippet?
     end
 
     def each_template


### PR DESCRIPTION
See #134 for a previous attempt at a fix. But we ended up recommending to use `default` on all optional parameters. But this is not a good solution.

See context in: https://shopify.slack.com/archives/C01F4ASU4G7/p1613572406096700?thread_ts=1613513255.092400&cid=C01F4ASU4G7

Can be turned back on w/ `ignore_snippets: false`

Fixes #159