### PR TITLE
Fix possible stack overflows in UnusedAssign and UndefinedObject

### DIFF
--- a/lib/theme_check/checks/undefined_object.rb
+++ b/lib/theme_check/checks/undefined_object.rb
@@ -134,7 +134,7 @@ module ThemeCheck
       end
     end
 
-    def check_object(info, all_global_objects, render_node = nil)
+    def check_object(info, all_global_objects, render_node = nil, visited_snippets = Set.new)
       check_undefined(info, all_global_objects, render_node)
 
       info.each_snippet do |(snippet_name, node)|
@@ -143,7 +143,10 @@ module ThemeCheck
 
         snippet_variables = node.value.attributes.keys +
           Array[node.value.instance_variable_get("@alias_name")]
-        check_object(snippet_info, all_global_objects + snippet_variables, node)
+        unless visited_snippets.include?(snippet_name)
+          visited_snippets << snippet_name
+          check_object(snippet_info, all_global_objects + snippet_variables, node, visited_snippets)
+        end
       end
     end
 

--- a/lib/theme_check/checks/unused_assign.rb
+++ b/lib/theme_check/checks/unused_assign.rb
@@ -6,12 +6,13 @@ module ThemeCheck
     category :liquid
 
     class TemplateInfo < Struct.new(:used_assigns, :assign_nodes, :includes)
-      def collect_used_assigns(templates)
+      def collect_used_assigns(templates, visited = Set.new)
         collected = used_assigns
         # Check recursively inside included snippets for use
         includes.each do |name|
-          if templates[name]
-            collected += templates[name].collect_used_assigns(templates)
+          if templates[name] && !visited.include?(name)
+            visited << name
+            collected += templates[name].collect_used_assigns(templates, visited)
           end
         end
         collected

--- a/test/checks/undefined_object_test.rb
+++ b/test/checks/undefined_object_test.rb
@@ -338,4 +338,24 @@ class UndefinedObjectTest < Minitest::Test
       Undefined object `checkout_html_classes` at templates/index.liquid:1
     END
   end
+
+  def test_recursion
+    offenses = analyze_theme(
+      ThemeCheck::UndefinedObject.new,
+      "templates/index.liquid" => <<~END,
+        {% render 'one' %}
+      END
+      "snippets/one.liquid" => <<~END,
+        {% render 'two' %}
+      END
+      "snippets/two.liquid" => <<~END,
+        {% if some_end_condition %}
+          {% render 'one' %}
+        {% endif %}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Missing argument `some_end_condition` at snippets/one.liquid:1
+    END
+  end
 end

--- a/test/checks/unused_assign_test.rb
+++ b/test/checks/unused_assign_test.rb
@@ -54,4 +54,24 @@ class UnusedAssignTest < Minitest::Test
     )
     assert_offenses("", offenses)
   end
+
+  def test_recursion_in_includes
+    offenses = analyze_theme(
+      ThemeCheck::UnusedAssign.new,
+      "templates/index.liquid" => <<~END,
+        {% assign a = 1 %}
+        {% include 'one' %}
+      END
+      "snippets/one.liquid" => <<~END,
+        {% include 'two' %}
+        {{ a }}
+      END
+      "snippets/two.liquid" => <<~END,
+        {% if some_end_condition %}
+          {% include 'one' %}
+        {% endif %}
+      END
+    )
+    assert_offenses("", offenses)
+  end
 end


### PR DESCRIPTION
Both checks use recursion, and had no stop condition.

Not sure about the one in `UndefinedObject`, but it seems to work 🤞 

Fixes #165