### PR TITLE
Multiple categories

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,9 @@ Layout/LineLength:
 
 Lint/MissingSuper:
   Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/StringLiteralsInInterpolation:
+  Enabled: false

--- a/lib/theme_check/check.rb
+++ b/lib/theme_check/check.rb
@@ -19,6 +19,7 @@ module ThemeCheck
       :liquid,
       :translation,
       :json,
+      :performance,
     ]
 
     class << self
@@ -36,15 +37,19 @@ module ThemeCheck
         @severity if defined?(@severity)
       end
 
-      def category(category = nil)
-        if category
-          unless CATEGORIES.include?(category)
-            raise ArgumentError, "unknown category. Use: #{CATEGORIES.join(', ')}"
+      def categories(*categories)
+        @categories ||= []
+        if categories.any?
+          unknown_categories = categories.select { |category| !CATEGORIES.include?(category) }
+          if unknown_categories.any?
+            raise ArgumentError,
+              "unknown categories: #{unknown_categories.join(', ')}. Use: #{CATEGORIES.join(', ')}"
           end
-          @category = category
+          @categories = categories
         end
-        @category if defined?(@category)
+        @categories
       end
+      alias_method :category, :categories
 
       def doc(doc = nil)
         @doc = doc if doc
@@ -63,8 +68,8 @@ module ThemeCheck
       self.class.severity
     end
 
-    def category
-      self.class.category
+    def categories
+      self.class.categories
     end
 
     def doc
@@ -93,7 +98,7 @@ module ThemeCheck
 
     def to_s
       s = +"#{code_name}:\n"
-      properties = { severity: severity, category: category, doc: doc }.merge(options)
+      properties = { severity: severity, categories: categories, doc: doc }.merge(options)
       properties.each_pair do |name, value|
         s << "  #{name}: #{value}\n" if value
       end

--- a/lib/theme_check/checks/parser_blocking_javascript.rb
+++ b/lib/theme_check/checks/parser_blocking_javascript.rb
@@ -3,7 +3,7 @@ module ThemeCheck
   # Reports errors when trying to use parser-blocking script tags
   class ParserBlockingJavaScript < LiquidCheck
     severity :error
-    category :liquid
+    categories :liquid, :performance
 
     PARSER_BLOCKING_SCRIPT_TAG = %r{
       <script                                    # Find the start of a script tag

--- a/lib/theme_check/config.rb
+++ b/lib/theme_check/config.rb
@@ -83,8 +83,8 @@ module ThemeCheck
 
         check_class = ThemeCheck.const_get(check_name)
 
-        next if exclude_categories.include?(check_class.category)
-        next if only_categories.any? && !only_categories.include?(check_class.category)
+        next if check_class.categories.any? { |category| exclude_categories.include?(category) }
+        next if only_categories.any? && check_class.categories.none? { |category| only_categories.include?(category) }
 
         options_for_check = options.transform_keys(&:to_sym)
         options_for_check.delete(:enabled)

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -213,14 +213,14 @@ class ConfigTest < Minitest::Test
     config = ThemeCheck::Config.new(root: ".")
     config.only_categories = [:liquid]
     assert(config.enabled_checks.any?)
-    assert(config.enabled_checks.all? { |c| c.category == :liquid })
+    assert(config.enabled_checks.all? { |c| c.categories.include?(:liquid) })
   end
 
   def test_exclude_category
     config = ThemeCheck::Config.new(root: ".")
     config.exclude_categories = [:liquid]
     assert(config.enabled_checks.any?)
-    assert(config.enabled_checks.none? { |c| c.category == :liquid })
+    assert(config.enabled_checks.none? { |c| c.categories.include?(:liquid) })
   end
 
   def test_ignore


### PR DESCRIPTION
Add support for multiple check categories

Eg.:

```
categories :liquid, :performance
```

Then, we'll be able to run just the performance checks w/: `theme-check -c performance`