### PR TITLE
Fix multiple occurrences of UndefinedObject not being reported

### DIFF
--- a/lib/theme_check/checks/undefined_object.rb
+++ b/lib/theme_check/checks/undefined_object.rb
@@ -22,10 +22,12 @@ module ThemeCheck
 
       def add_variable_lookup(name:, node:)
         parent = node
-        begin
+        line_number = nil
+        loop do
           line_number = parent.line_number
           parent = parent.parent
-        end while line_number.nil? && parent
+          break unless line_number.nil? && parent
+        end
         key = [name, line_number]
         @all_variable_lookups[key] = node
       end

--- a/lib/theme_check/checks/undefined_object.rb
+++ b/lib/theme_check/checks/undefined_object.rb
@@ -21,7 +21,11 @@ module ThemeCheck
       end
 
       def add_variable_lookup(name:, node:)
-        line_number = node.parent.line_number
+        parent = node
+        begin
+          line_number = parent.line_number
+          parent = parent.parent
+        end while line_number.nil? && parent
         key = [name, line_number]
         @all_variable_lookups[key] = node
       end
@@ -154,7 +158,7 @@ module ThemeCheck
       all_variables = info.all_variables
 
       info.each_variable_lookup(!!render_node) do |(key, node)|
-        name, _line_number = key
+        name, line_number = key
         next if all_variables.include?(name)
         next if all_global_objects.include?(name)
 
@@ -164,7 +168,7 @@ module ThemeCheck
         if render_node
           add_offense("Missing argument `#{name}`", node: render_node)
         else
-          add_offense("Undefined object `#{name}`", node: node)
+          add_offense("Undefined object `#{name}`", node: node, line_number: line_number)
         end
       end
     end

--- a/test/checks/undefined_object_test.rb
+++ b/test/checks/undefined_object_test.rb
@@ -53,6 +53,23 @@ class UndefinedObjectTest < Minitest::Test
     END
   end
 
+  def test_reports_several_offenses_for_same_object
+    offenses = analyze_theme(
+      ThemeCheck::UndefinedObject.new,
+      "templates/index.liquid" => <<~END,
+        {% if form[email] %}
+          {{ form[email] }}
+          {{ form[email] }}
+        {% endif %}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Undefined object `email` at templates/index.liquid:1
+      Undefined object `email` at templates/index.liquid:2
+      Undefined object `email` at templates/index.liquid:3
+    END
+  end
+
   def test_does_not_report_on_string_argument_to_global_object
     offenses = analyze_theme(
       ThemeCheck::UndefinedObject.new,


### PR DESCRIPTION
Fixes #186

The issue seemed to be caused by missing line_number for VariableLookup nodes.

Solution: Walk back the parent nodes until we find a line number.
