### PR TITLE
Ignore new Rubocop errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,9 @@ Layout/LineLength:
 
 Lint/MissingSuper:
   Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/StringLiteralsInInterpolation:
+  Enabled: false


### PR DESCRIPTION
To fix the build. Seems those new rules are now on by default, and they were not before.