### PR TITLE
Add Documentation Template + TemplateLength Check Documentation

### DIFF
--- a/docs/checks/CHECK_DOCS_TEMPLATE.md
+++ b/docs/checks/CHECK_DOCS_TEMPLATE.md
@@ -43,5 +43,5 @@ This check has been introduced in Theme Check X.X.X.
 - [Rule Source][codesource]
 - [Documentation Source][docsource]
 
-[codesource]: lib/theme_check/checks/check_class_name.rb
-[docsource]: docs/checks/check_class_name.md
+[codesource]: /lib/theme_check/checks/check_class_name.rb
+[docsource]: /docs/checks/check_class_name.md

--- a/docs/checks/CHECK_DOCS_TEMPLATE.md
+++ b/docs/checks/CHECK_DOCS_TEMPLATE.md
@@ -1,0 +1,47 @@
+# Check Title (`CheckClassName`)
+
+A brief paragraph explaining why the check exists.
+
+## Check Details
+
+This check is aimed at eliminating ...
+
+:-1: Examples of **incorrect** code for this check:
+
+```liquid
+```
+
+:+1: Examples of **correct** code for this check:
+
+```liquid
+```
+
+## Check Options
+
+The default configuration for this check is the following:
+
+```
+CheckClassName:
+  enabled: true
+  some_option: 10
+```
+
+### `some_option`
+
+The `some_option` option (Default: `10`) determines ...
+
+## When Not To Use It
+
+If you don't want to ..., then it's safe to disable this rule.
+
+## Version
+
+This check has been introduced in Theme Check X.X.X.
+
+## Resources
+
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[codesource]: lib/theme_check/checks/check_class_name.rb
+[docsource]: docs/checks/check_class_name.md

--- a/docs/checks/CHECK_DOCS_TEMPLATE.md
+++ b/docs/checks/CHECK_DOCS_TEMPLATE.md
@@ -20,7 +20,7 @@ This check is aimed at eliminating ...
 
 The default configuration for this check is the following:
 
-```
+```yaml
 CheckClassName:
   enabled: true
   some_option: 10

--- a/docs/checks/template_length.md
+++ b/docs/checks/template_length.md
@@ -18,7 +18,7 @@ This check is aimed at eliminating large template files.
 
 The default configuration for this check is the following:
 
-```
+```yaml
 TemplateLength:
   enabled: true
   max_length: 200

--- a/docs/checks/template_length.md
+++ b/docs/checks/template_length.md
@@ -1,0 +1,50 @@
+# Discourage the use of large template files (`TemplateLength`)
+
+This check exists to discourage the use of large template files. Use snippets to componentize your theme.
+
+## Check Details
+
+This check is aimed at eliminating large template files.
+
+:-1: Examples of **incorrect** code for this check:
+
+- Files that have more lines than the threshold
+
+:+1: Examples of **correct** code for this check:
+
+- Files that have less lines than the threshold
+
+## Check Options
+
+The default configuration for this check is the following:
+
+```
+TemplateLength:
+  enabled: true
+  max_length: 200
+  exclude_schema: true
+```
+
+### `max_length`
+
+The `max_length` (Default: `200`) option determines the maximum number of lines allowed inside a liquid file.
+
+### `exclude_schema`
+
+The `exclude_schema` (Default: `true`) option determines if the schema lines from a template should be excluded from the line count.
+
+## When Not To Use It
+
+If you don't care about template lengths, then it's safe to disable this rule.
+
+## Version
+
+This check has been introduced in Theme Check 0.1.0.
+
+## Resources
+
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[codesource]: /lib/theme_check/checks/template_length.rb
+[docsource]: /docs/checks/template_length.md

--- a/lib/theme_check/check.rb
+++ b/lib/theme_check/check.rb
@@ -51,6 +51,10 @@ module ThemeCheck
         @doc if defined?(@doc)
       end
 
+      def docs_url(path)
+        "https://github.com/Shopify/theme-check/blob/master/#{path}"
+      end
+
       def can_disable(disableable = nil)
         unless disableable.nil?
           @can_disable = disableable

--- a/lib/theme_check/checks/template_length.rb
+++ b/lib/theme_check/checks/template_length.rb
@@ -3,6 +3,7 @@ module ThemeCheck
   class TemplateLength < LiquidCheck
     severity :suggestion
     category :liquid
+    doc docs_url("docs/checks/template_length.md")
 
     def initialize(max_length: 200, exclude_schema: true)
       @max_length = max_length

--- a/lib/theme_check/language_server/handler.rb
+++ b/lib/theme_check/language_server/handler.rb
@@ -138,12 +138,20 @@ module ThemeCheck
       end
 
       def offense_to_diagnostic(offense)
-        {
+        diagnostic = {
+          code: offense.code_name,
+          message: offense.message,
           range: range(offense),
           severity: severity(offense),
-          code: offense.code_name,
           source: "theme-check",
-          message: offense.message,
+        }
+        diagnostic["codeDescription"] = code_description(offense) unless offense.doc.nil?
+        diagnostic
+      end
+
+      def code_description(offense)
+        {
+          href: offense.doc,
         }
       end
 

--- a/lib/theme_check/language_server/server.rb
+++ b/lib/theme_check/language_server/server.rb
@@ -10,11 +10,13 @@ module ThemeCheck
 
     class Server
       attr_reader :handler
+      attr_reader :should_raise_errors
 
       def initialize(
         in_stream: STDIN,
         out_stream: STDOUT,
-        err_stream: $DEBUG ? File.open('/tmp/lsp.log', 'a') : STDERR
+        err_stream: $DEBUG ? File.open('/tmp/lsp.log', 'a') : STDERR,
+        should_raise_errors: false
       )
         validate!([in_stream, out_stream, err_stream])
 
@@ -25,6 +27,8 @@ module ThemeCheck
 
         @out.sync = true # do not buffer
         @err.sync = true # do not buffer
+
+        @should_raise_errors = should_raise_errors
       end
 
       def listen
@@ -37,6 +41,7 @@ module ThemeCheck
           return 0
 
         rescue Exception => e # rubocop:disable Lint/RescueException
+          raise e if should_raise_errors
           log(e)
           log(e.backtrace)
           return 1

--- a/test/language_server_test.rb
+++ b/test/language_server_test.rb
@@ -11,7 +11,8 @@ class LanguageServerTest < Minitest::Test
     @server = ThemeCheck::LanguageServer::Server.new(
       in_stream: @in,
       out_stream: @out,
-      err_stream: @err
+      err_stream: @err,
+      should_raise_errors: true
     )
   end
 
@@ -24,6 +25,7 @@ class LanguageServerTest < Minitest::Test
     :end_column,
     :start_line,
     :end_line,
+    :doc,
   ) do
     def self.build(path)
       new(
@@ -35,6 +37,7 @@ class LanguageServerTest < Minitest::Test
         14,
         9,
         9,
+        "https://path.to/docs.md"
       )
     end
   end
@@ -95,6 +98,9 @@ class LanguageServerTest < Minitest::Test
           },
           severity: 3,
           code: "LiquidTag",
+          codeDescription: {
+            href: "https://path.to/docs.md",
+          },
           source: "theme-check",
           message: "Wrong",
         }],
@@ -154,6 +160,9 @@ class LanguageServerTest < Minitest::Test
           },
           severity: 3,
           code: "LiquidTag",
+          codeDescription: {
+            href: "https://path.to/docs.md",
+          },
           source: "theme-check",
           message: "Wrong",
         }],
@@ -259,6 +268,9 @@ class LanguageServerTest < Minitest::Test
           },
           severity: 3,
           code: "LiquidTag",
+          codeDescription: {
+            href: "https://path.to/docs.md",
+          },
           source: "theme-check",
           message: "Wrong",
         }],
@@ -298,6 +310,8 @@ class LanguageServerTest < Minitest::Test
       body = scanner.peek(len)
       actual_responses << JSON.parse(body).deep_symbolize_keys
     end
-    assert_equal(expected_responses, actual_responses)
+    expected_responses.each do |response|
+      assert_equal(response, actual_responses.shift)
+    end
   end
 end


### PR DESCRIPTION
Add a check documentation template + a way to link to the documentation (from within the repo) in check classes.

This also implements the codeDescription property in diagnostics so that the docs can be accessed from within the editor:

https://screenshot.click/10-29-cjx7r-4asor.mp4

Related #195 