### PR TITLE
Theme Check Documentation Spree (part 1)

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -10,6 +10,7 @@ ConvertIncludeToRender:
 
 LiquidTag:
   enabled: true
+  min_consecutive_statements: 4
 
 MissingTemplate:
   enabled: true

--- a/docs/checks/default_locale.md
+++ b/docs/checks/default_locale.md
@@ -1,0 +1,46 @@
+# Ensure theme has a default locale (`DefaultLocale`)
+
+This check makes sure the theme has a default translation file.
+
+## Check Details
+
+This check makes sure a theme has a default locale.
+
+:-1: Example of **incorrect** theme for this check:
+
+```
+locales/
+├── en.json
+├── fr.json
+└── zh-TW.json
+```
+
+:+1: Example of **correct** theme for this check:
+
+```
+locales/
+├── en.default.json  # a default translation file is required
+├── fr.json
+└── zh-TW.json
+```
+
+## Check Options
+
+The default configuration for this check is the following:
+
+```yaml
+DefaultLocale:
+  enabled: true
+```
+
+## Version
+
+This check has been introduced in Theme Check 0.1.0.
+
+## Resources
+
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[codesource]: /lib/theme_check/checks/default_locale.rb
+[docsource]: /docs/checks/default_locale.md

--- a/docs/checks/deprecated_filter.md
+++ b/docs/checks/deprecated_filter.md
@@ -1,0 +1,46 @@
+# Discourage use of deprecated filters (`DeprecatedFilter`)
+
+This check discourages the use of [deprecated filters][deprecated].
+
+## Check Details
+
+This check is aimed at eliminating deprecated filters.
+
+:-1: Example of **incorrect** code for this check:
+
+```liquid
+.site-footer p {
+  color: {{ settings.color_name | hex_to_rgba: 0.5 }};
+}
+```
+
+:+1: Example of **correct** code for this check:
+
+```liquid
+.site-footer p {
+  color: {{ settings.color_name | color_modify: 'alpha', 0.5 }};
+}
+```
+
+## Check Options
+
+The default configuration for this check is the following:
+
+```yaml
+DeprecatedFilter:
+  enabled: true
+```
+
+## Version
+
+This check has been introduced in Theme Check 0.2.0.
+
+## Resources
+
+- [Deprecated Filters Reference][deprecated]
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[deprecated]: https://shopify.dev/docs/themes/liquid/reference/filters/deprecated-filters
+[codesource]: /lib/theme_check/checks/deprecated_filter.rb
+[docsource]: /docs/checks/deprecated_filter.md

--- a/docs/checks/liquid_tag.md
+++ b/docs/checks/liquid_tag.md
@@ -1,0 +1,65 @@
+# Encourage use of liquid tag for consecutive statements (LiquidTag)
+
+Recommends using `{% liquid ... %}` if 4 or more consecutive liquid tags (`{% ... %}`) are found.
+
+## Check Details
+
+This check is aimed at eliminating repetitive tag markers (`{%` and `%}`) in theme files.
+
+:-1: Example of **incorrect** code for this check:
+
+```liquid
+{% if collection.image.size != 0 %}
+{%   assign collection_image = collection.image %}
+{% elsif collection.products.first.size != 0 and collection.products.first.media != empty %}
+{%   assign collection_image = collection.products.first.featured_media.preview_image %}
+{% else %}
+{%   assign collection_image = nil %}
+{% endif %}
+```
+
+:+1: Example of **correct** code for this check:
+
+```liquid
+{%- liquid
+  if collection.image.size != 0
+    assign collection_image = collection.image
+  elsif collection.products.first.size != 0 and collection.products.first.media != empty
+    assign collection_image = collection.products.first.featured_media.preview_image
+  else
+    assign collection_image = nil
+  endif
+-%}
+```
+
+## Check Options
+
+The default configuration for this check is the following:
+
+```yaml
+LiquidTag:
+  enabled: true
+  min_consecutive_statements: 4
+```
+
+### `min_consecutive_statements`
+
+The `min_consecutive_statements` option (Default: `4`) determines the maximum (inclusive) number of consecutive statements before the check recommends a refactor.
+
+## When Not To Use It
+
+It's safe to disable this rule.
+
+## Version
+
+This check has been introduced in Theme Check 0.1.0.
+
+## Resources
+
+- [`{% liquid %}` Tag Reference][liquid]
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[liquid] https://shopify.dev/docs/themes/liquid/reference/tags/theme-tags#liquid
+[codesource]: /lib/theme_check/checks/liquid_tag.rb
+[docsource]: /docs/checks/liquid_tag.md

--- a/docs/checks/matching_schema_translations.md
+++ b/docs/checks/matching_schema_translations.md
@@ -1,0 +1,84 @@
+# Spot errors in schema translations (`MatchingSchemaTranslations`)
+
+Validates translations in schema tags (`{% schema %}`).
+
+## Check Details
+
+Add checks for eliminating translations mistakes in schema tags.
+
+:-1: Examples of **incorrect** code for this check:
+
+```liquid
+{% comment %}
+  - fr.missing is missing
+  - fr.extra is not in the default locale
+{% endcomment %}
+{% schema %}
+  {
+    "locales": {
+      "en": {
+        "title": "Welcome",
+        "missing": "Product"
+      },
+      "fr": {
+        "title": "Bienvenue",
+        "extra": "Extra"
+      }
+    }
+  }
+{% endschema %}
+
+{% comment %}
+  - The French product label is missing.
+{% endcomment %}
+{% schema %}
+  {
+    "name": {
+      "en": "Hello",
+      "fr": "Bonjour"
+    },
+    "settings": [
+      {
+        "id": "product",
+        "label": {
+          "en": "Product"
+        }
+      }
+    ]
+  }
+{% endschema %}
+```
+
+:+1: Examples of **correct** code for this check:
+
+```liquid
+{% schema %}
+  {
+    "name": {
+      "en": "Hello",
+      "fr": "Bonjour"
+    },
+    "settings": [
+      {
+        "id": "product",
+        "label": {
+          "en": "Product",
+          "fr": "Produit"
+        }
+      }
+    ]
+  }
+{% endschema %}
+```
+
+## Version
+
+This check has been introduced in Theme Check 0.1.0.
+
+## Resources
+
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[codesource]: /lib/theme_check/checks/matching_schema_translations.rb
+[docsource]: /docs/checks/matching_schema_translations.md

--- a/docs/checks/matching_translations.md
+++ b/docs/checks/matching_translations.md
@@ -1,0 +1,63 @@
+# Prevent mismatching translations (`MatchingTranslations`)
+
+This check exists to prevent missing and superfluous translations in locale files.
+
+## Check Details
+
+This check warns against missing translations in locale files.
+
+:-1: Examples of **incorrect** code for this check:
+
+```js
+// en.default.json
+{
+  "greeting": "Hello, world",
+  "goodbye": "Bye, world"
+}
+
+// fr.json - missing `greeting` and `goodbye`
+{
+}
+
+// fr.json - missing `greeting` and superfluous `goodby`
+{
+  "greeting": "Bonjour, monde"
+  "goodby": "Au revoir, monde"
+}
+```
+
+:+1: Example of **correct** code for this check:
+
+```liquid
+// en.default.json
+{
+  "greeting": "Hello, world",
+  "goodbye": "Bye, world"
+  "pluralized_greeting": {
+    "one": "Hello, you",
+    "other": "Hello, y'all",
+  }
+}
+
+// fr.json
+{
+  "greeting": "Bonjour, monde"
+  "goodbye": "Au revoir, monde"
+  "pluralized_greeting": {
+    "zero": "Je suis seul :(",
+    "few": "Salut, groupe!"
+  }
+}
+```
+
+## Version
+
+This check has been introduced in Theme Check 0.1.0.
+
+## Resources
+
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[codesource]: /lib/theme_check/checks/matching_translations.rb
+[docsource]: /docs/checks/matching_translations.md

--- a/docs/checks/missing_enable_comment.md
+++ b/docs/checks/missing_enable_comment.md
@@ -1,0 +1,50 @@
+# Prevent missing theme-check-enable comments (`MissingEnableComment`)
+
+When `theme-check-disable` is used in the middle of a template, the corresponding `theme-check-enable` comment should also be included.
+
+## Check Details
+
+This check aims at eliminating missing `theme-check-enable` comments.
+
+:-1: Example of **incorrect** code for this check:
+
+```liquid
+<!doctype html>
+<html>
+  <head>
+    {% comment %}theme-check-disable ParserBlockingJavaScript{% endcomment %}
+    <script src="https://cdnjs.com/jquery.min.js"></script>
+  </head>
+  <body>
+    <!-- ... -->
+  </body>
+</html>
+```
+
+:+1: Example of **correct** code for this check:
+
+```liquid
+<!doctype html>
+<html>
+  <head>
+    {% comment %}theme-check-disable ParserBlockingJavaScript{% endcomment %}
+    <script src="https://cdnjs.com/jquery.min.js"></script>
+    {% comment %}theme-check-enable ParserBlockingJavaScript{% endcomment %}
+  </head>
+  <body>
+    <!-- ... -->
+  </body>
+</html>
+```
+
+## Version
+
+This check has been introduced in Theme Check 0.3.0.
+
+## Resources
+
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[codesource]: /lib/theme_check/checks/missing_enable_comment.rb
+[docsource]: /docs/checks/missing_enable_comment.md

--- a/lib/theme_check/checks/default_locale.rb
+++ b/lib/theme_check/checks/default_locale.rb
@@ -3,6 +3,7 @@ module ThemeCheck
   class DefaultLocale < JsonCheck
     severity :suggestion
     category :translation
+    doc docs_url("docs/checks/default_locale.md")
 
     def on_end
       return if @theme.default_locale_json

--- a/lib/theme_check/checks/deprecated_filter.rb
+++ b/lib/theme_check/checks/deprecated_filter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module ThemeCheck
   class DeprecatedFilter < LiquidCheck
-    doc "https://shopify.dev/docs/themes/liquid/reference/filters/deprecated-filters"
+    doc docs_url("docs/checks/deprecated_filter.md")
     category :liquid
     severity :suggestion
 

--- a/lib/theme_check/checks/liquid_tag.rb
+++ b/lib/theme_check/checks/liquid_tag.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 module ThemeCheck
-  # Recommends using {% liquid ... %} if 3 or more consecutive {% ... %} are found.
+  # Recommends using {% liquid ... %} if 4 or more consecutive {% ... %} are found.
   class LiquidTag < LiquidCheck
     severity :suggestion
     category :liquid
-    doc "https://shopify.dev/docs/themes/liquid/reference/tags/theme-tags#liquid"
+    doc docs_url("docs/checks/liquid_tag.md")
 
-    def initialize(min_consecutive_statements: 10)
+    def initialize(min_consecutive_statements: 4)
       @first_statement = nil
       @consecutive_statements = 0
       @min_consecutive_statements = min_consecutive_statements

--- a/lib/theme_check/checks/matching_schema_translations.rb
+++ b/lib/theme_check/checks/matching_schema_translations.rb
@@ -3,6 +3,7 @@ module ThemeCheck
   class MatchingSchemaTranslations < LiquidCheck
     severity :suggestion
     category :translation
+    doc docs_url("checks/docs/matching_schema_translations.rb")
 
     def on_schema(node)
       schema = JSON.parse(node.value.nodelist.join)

--- a/lib/theme_check/checks/matching_translations.rb
+++ b/lib/theme_check/checks/matching_translations.rb
@@ -4,6 +4,7 @@ module ThemeCheck
   class MatchingTranslations < JsonCheck
     severity :suggestion
     category :translation
+    doc docs_url("docs/checks/matching_translations.md")
 
     def initialize
       @files = []

--- a/lib/theme_check/checks/missing_enable_comment.rb
+++ b/lib/theme_check/checks/missing_enable_comment.rb
@@ -2,6 +2,7 @@
 module ThemeCheck
   class MissingEnableComment < LiquidCheck
     severity :error
+    doc docs_url("docs/checks/missing_enable_comment.md")
 
     # Don't allow this check to be disabled with a comment,
     # as we need to be able to check for disabled checks.


### PR DESCRIPTION
Add documentation for the following checks:
  * MissingEnableComment
  * MatchingTranslations
  * MatchingSchemaTranslations
  * LiquidTag + reduce default to 4 consecutive statements
  * DeprecatedFilter
  * DefaultLocale