### PR TITLE
Add AssetSizeCSS Check

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -85,4 +85,8 @@ ParserBlockingJavaScript:
 
 AssetSizeJavaScript:
   enabled: false
-  threshold_in_bytes: 10000
+  threshold_in_bytes: 10_000
+
+AssetSizeCSS:
+  enabled: false
+  threshold_in_bytes: 100_000

--- a/docs/checks/asset_size_css.md
+++ b/docs/checks/asset_size_css.md
@@ -1,0 +1,52 @@
+# Prevent Large CSS bundles (`AssetSizeCSS`)
+
+This rule exists to prevent large CSS bundles (for speed).
+
+## Check Details
+
+This rule disallows the use of too much CSS in themes, as configured by `threshold_in_bytes`.
+
+:-1: Examples of **incorrect** code for this check:
+```liquid
+<!-- Here, assets/theme.css is **greater** than `threshold_in_bytes` compressed. -->
+{{ 'theme.css' | asset_url | stylesheet_tag }}
+```
+
+:+1: Example of **correct** code for this check:
+```liquid
+<!-- Here, assets/theme.css is **less** than `threshold_in_bytes` compressed. -->
+{{ 'theme.css' | asset_url | stylesheet_tag }}
+```
+
+## Check Options
+
+The default configuration is the following.
+
+```yaml
+AssetSizeCSS:
+  enabled: false
+  threshold_in_bytes: 100_000
+```
+
+### `threshold_in_bytes`
+
+The `threshold_in_bytes` option (default: `100_000`) determines the maximum allowed compressed size in bytes that a single CSS file can take.
+
+This includes theme and remote stylesheets.
+
+## When Not To Use It
+
+This rule is safe to disable.
+
+## Version
+
+This check has been introduced in Theme Check THEME_CHECK_VERSION.
+
+## Resources
+
+- [The Performance Inequality Gap](https://infrequently.org/2021/03/the-performance-inequality-gap/)
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[codesource]: /lib/theme_check/checks/asset_size_css.rb
+[docsource]: /docs/checks/asset_size_css.md

--- a/lib/theme_check/checks/asset_size_css.rb
+++ b/lib/theme_check/checks/asset_size_css.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+module ThemeCheck
+  class AssetSizeCSS < LiquidCheck
+    include RegexHelpers
+    severity :error
+    category :performance
+    doc docs_url(__FILE__)
+
+    Link = Struct.new(:href, :index)
+
+    TAG = /#{Liquid::TagStart}.*?#{Liquid::TagEnd}/om
+    VARIABLE = /#{Liquid::VariableStart}.*?#{Liquid::VariableEnd}/om
+    START_OR_END_QUOTE = /(^['"])|(['"]$)/
+    LINK_TAG_HREF = %r{
+      <link
+        (?=(?:[^>]|\n|\r)+?rel=['"]?stylesheet['"]?)+?  # Make sure rel=stylesheet is in the link with lookahead
+        [^>]+                                           # any non closing tag character
+        href=                                           # href attribute start
+        (?<href>
+          '(?:#{TAG}|#{VARIABLE}|[^']+)*'|              # any combination of tag/variable or non straight quote inside straight quotes
+          "(?:#{TAG}|#{VARIABLE}|[^"]+)*"               # any combination of tag/variable or non double quotes inside double quotes
+        )
+        [^>]*                                           # any non closing character till the end
+      >
+    }omix
+    STYLESHEET_TAG = %r{
+      #{Liquid::VariableStart}          # VariableStart
+      (?:(?!#{Liquid::VariableEnd}).)*? # anything that isn't followed by a VariableEnd
+      \|\s*asset_url\s*                 # | asset_url
+      \|\s*stylesheet_tag\s*            # | stylesheet_tag
+      #{Liquid::VariableEnd}            # VariableEnd
+    }omix
+
+    attr_reader :threshold_in_bytes
+
+    def initialize(threshold_in_bytes: 100_000)
+      @threshold_in_bytes = threshold_in_bytes
+    end
+
+    def on_document(node)
+      @node = node
+      @source = node.template.source
+      record_offenses
+    end
+
+    def record_offenses
+      stylesheets(@source).each do |stylesheet|
+        file_size = href_to_file_size(stylesheet.href)
+        next if file_size.nil?
+        next if file_size <= threshold_in_bytes
+        add_offense(
+          "CSS on every page load exceding compressed size threshold (#{threshold_in_bytes} Bytes).",
+          node: @node,
+          markup: stylesheet.href,
+          line_number: @source[0...stylesheet.index].count("\n") + 1
+        )
+      end
+    end
+
+    def stylesheets(source)
+      stylesheet_links = matches(source, LINK_TAG_HREF)
+        .map do |m|
+          Link.new(
+            m[:href].gsub(START_OR_END_QUOTE, ""),
+            m.begin(:href),
+          )
+        end
+
+      stylesheet_tags = matches(source, STYLESHEET_TAG)
+        .map do |m|
+          Link.new(
+            m[0],
+            m.begin(0),
+          )
+        end
+
+      stylesheet_links + stylesheet_tags
+    end
+
+    def href_to_file_size(href)
+      # asset_url (+ optional stylesheet_tag) variables
+      if href =~ /^#{VARIABLE}$/o && href =~ /asset_url/ && href =~ Liquid::QuotedString
+        asset_id = Regexp.last_match(0).gsub(START_OR_END_QUOTE, "")
+        asset = @theme.assets.find { |a| a.name.ends_with?("/" + asset_id) }
+        return if asset.nil?
+        asset.gzipped_size
+
+      # remote URLs
+      elsif href =~ %r{^(https?:)?//}
+        asset = RemoteAssetFile.from_src(href)
+        asset.gzipped_size
+      end
+    end
+  end
+end

--- a/test/checks/asset_size_css_test.rb
+++ b/test/checks/asset_size_css_test.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module ThemeCheck
+  class AssetSizeCSSTest < Minitest::Test
+    def test_link_tag_regex
+      # using quotes
+      assert_href(<<~EXPECTED.strip, <<~SOURCE)
+        "{{ 'theme.css' | asset_url }}"
+      EXPECTED
+        <link href="{{ 'theme.css' | asset_url }}" rel="stylesheet">
+      SOURCE
+
+      # using straight quotes
+      assert_href(<<~EXPECTED.strip, <<~SOURCE)
+        '{{ 'theme.css' | asset_url }}'
+      EXPECTED
+        <link rel="stylesheet" href='{{ 'theme.css' | asset_url }}'>
+      SOURCE
+
+      # with follow up boolean attribute
+      assert_href(<<~EXPECTED.strip, <<~SOURCE)
+        "/theme.css"
+      EXPECTED
+        <link rel="stylesheet" href="/theme.css" disabled>
+      SOURCE
+
+      # with whitespace after boolean attribute
+      assert_href(<<~EXPECTED.strip, <<~SOURCE)
+        "theme.css"
+      EXPECTED
+        <link
+          rel="stylesheet"
+          href="theme.css"
+          media="all"
+          disabled
+        ></script>
+      SOURCE
+
+      # with whitespace inside variable
+      assert_href(<<~EXPECTED.strip, <<~SOURCE)
+        '{{
+            'theme.css' | asset_url
+          }}'
+      EXPECTED
+        <link
+          href='{{
+            'theme.css' | asset_url
+          }}'
+          rel="stylesheet"
+        ></script>
+      SOURCE
+    end
+
+    def assert_href(expected, source)
+      match = AssetSizeCSS::LINK_TAG_HREF.match(source)
+      assert(match, "Expected to extract #{expected} from #{source}")
+      assert_equal(expected, match[:href])
+    end
+
+    def test_stylesheet_extractor
+      check = AssetSizeCSS.new
+      stylesheets = check.stylesheets(<<~SOURCE)
+        <html>
+          <head>
+            <link href="{{ '1.css' | asset_url }}" rel="stylesheet" disabled>
+            <link href="{{ '2.css' | asset_url }}" rel="stylesheet" media="all">
+            <link href="3.css" rel="stylesheet">
+            <link rel="stylesheet" href="4.css">
+            {{ '5.css' | asset_url | stylesheet_tag }}
+            <link rel="preload" href="not-this.css">
+          </head>
+        </html>
+      SOURCE
+
+      expected = [
+        "{{ '1.css' | asset_url }}",
+        "{{ '2.css' | asset_url }}",
+        "3.css",
+        "4.css",
+        "{{ '5.css' | asset_url | stylesheet_tag }}",
+      ]
+
+      assert_equal(expected, stylesheets.map(&:href))
+    end
+
+    def test_href_to_file_size
+      theme = make_theme({
+        "assets/theme.css" => "* { color: green !important; }",
+      })
+
+      assert_has_file_size("{{ 'theme.css' | asset_url }}", theme)
+      RemoteAssetFile.any_instance.expects(:gzipped_size).times(3).returns(42)
+      assert_has_file_size("https://example.com/foo.css", theme)
+      assert_has_file_size("http://example.com/foo.css", theme)
+      assert_has_file_size("//example.com/foo.css", theme)
+
+      refute_has_file_size("{{ 'this_file_does_not_exist.css' | asset_url }}", theme)
+      refute_has_file_size("{% if on_product %}https://hello.world{% else %}https://hi.world{% endif %}", theme)
+    end
+
+    def assert_has_file_size(href, theme)
+      check = AssetSizeCSS.new
+      check.theme = theme
+      fs = check.href_to_file_size(href)
+      assert(fs, "expected `#{href}` to have a file size.")
+    end
+
+    def refute_has_file_size(href, theme)
+      check = AssetSizeCSS.new
+      check.theme = theme
+      fs = check.href_to_file_size(href)
+      refute(fs, "didn't expect to get a file size for `#{href}`.")
+    end
+
+    def test_css_bundles_smaller_than_threshold
+      offenses = analyze_theme(
+        AssetSizeCSS.new(threshold_in_bytes: 10000000),
+        {
+          "assets/theme.css" => <<~JS,
+            console.log('hello world');
+          JS
+          "templates/index.liquid" => <<~END,
+            <html>
+              <head>
+                <link href="{{ 'theme.css' | asset_url }}" rel="stylesheet">
+                {{ 'theme.css' | asset_url | stylesheet_tag }}
+              </head>
+            </html>
+          END
+        }
+      )
+      assert_offenses("", offenses)
+    end
+
+    def test_css_bundles_bigger_than_threshold
+      offenses = analyze_theme(
+        AssetSizeCSS.new(threshold_in_bytes: 2),
+        "assets/theme.css" => <<~JS,
+          console.log('hello world');
+        JS
+        "templates/index.liquid" => <<~END,
+          <html>
+            <head>
+              <link href="{{ 'theme.css' | asset_url }}" rel="stylesheet">
+              {{ 'theme.css' | asset_url | stylesheet_tag }}
+            </head>
+          </html>
+        END
+      )
+      assert_offenses(<<~END, offenses)
+        CSS on every page load exceding compressed size threshold (2 Bytes). at templates/index.liquid:3
+        CSS on every page load exceding compressed size threshold (2 Bytes). at templates/index.liquid:4
+      END
+    end
+  end
+end

--- a/test/config_default_test.rb
+++ b/test/config_default_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "test_helper"
+require "yaml"
+
+module ThemeCheck
+  class ConfigDefaultTest < Minitest::Test
+    def setup
+      @default_config = YAML.load(default_config_path.read)
+    end
+
+    def test_all_checks_are_in_config_default_yml
+      Check.all.each do |check_class|
+        check = check_class.new
+        next if check.code_name == "MockCheck"
+        refute_nil(@default_config.dig(check.code_name), "#{check.code_name} and its default configuration should be included in config/default.yml")
+        refute_nil(@default_config.dig(check.code_name, 'enabled'), "#{check.code_name} should have a default 'enabled:' value in config/default.yml")
+      end
+    end
+
+    private
+
+    def default_config_path
+      Pathname.new(__dir__) + '../config/default.yml'
+    end
+  end
+end


### PR DESCRIPTION
Fixes #189

This check is a lot like AssetSizeJavaScript but for CSS.

- Disabled by default
- Default value = 100KB
- Link to Alex Russells' Performance Inequality Gap in docs