### PR TITLE
Add `-C, --config path` support

### DIFF
--- a/lib/theme_check/cli.rb
+++ b/lib/theme_check/cli.rb
@@ -7,13 +7,14 @@ module ThemeCheck
       Usage: theme-check [options] /path/to/your/theme
 
       Options:
-        -c, [--category]          # Only run this category of checks
-        -x, [--exclude-category]  # Exclude this category of checks
-        -l, [--list]              # List enabled checks
-        -a, [--auto-correct]      # Automatically fix offenses
-        --init                    # Generate a .theme-check.yml file in the current directory
-        -h, [--help]              # Show this. Hi!
-        -v, [--version]           # Print Theme Check version
+        --init                               Generate a .theme-check.yml file in the current directory
+        -C, --config <path>                  Use the config provided, overriding .theme-check.yml if present
+        -c, --category <category>            Only run this category of checks
+        -x, --exclude-category  <category>   Exclude this category of checks
+        -l, --list                           List enabled checks
+        -a, --auto-correct                   Automatically fix offenses
+        -h, --help                           Show this. Hi!
+        -v, --version                        Print Theme Check version
 
       Description:
         Theme Check helps you follow Shopify Themes & Liquid best practices by analyzing the
@@ -29,6 +30,7 @@ module ThemeCheck
       only_categories = []
       exclude_categories = []
       auto_correct = false
+      config_path = nil
 
       args = argv.dup
       while (arg = args.shift)
@@ -37,6 +39,8 @@ module ThemeCheck
           raise Abort, USAGE
         when "--version", "-v"
           command = :version
+        when "--config", "-C"
+          config_path = Pathname.new(args.shift)
         when "--category", "-c"
           only_categories << args.shift.to_sym
         when "--exclude-category", "-x"
@@ -53,7 +57,14 @@ module ThemeCheck
       end
 
       unless [:version, :init].include?(command)
-        @config = ThemeCheck::Config.from_path(@path)
+        @config = if config_path.present?
+          ThemeCheck::Config.new(
+            root: @path,
+            configuration: ThemeCheck::Config.load_file(config_path)
+          )
+        else
+          ThemeCheck::Config.from_path(@path)
+        end
         @config.only_categories = only_categories
         @config.exclude_categories = exclude_categories
         @config.auto_correct = auto_correct

--- a/lib/theme_check/config.rb
+++ b/lib/theme_check/config.rb
@@ -10,6 +10,8 @@ module ThemeCheck
     attr_accessor :only_categories, :exclude_categories, :auto_correct
 
     class << self
+      attr_reader :last_loaded_config
+
       def from_path(path)
         if (filename = find(path))
           new(root: filename.dirname, configuration: load_file(filename))
@@ -36,6 +38,7 @@ module ThemeCheck
       end
 
       def load_file(absolute_path)
+        @last_loaded_config = absolute_path
         YAML.load_file(absolute_path)
       end
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -22,6 +22,25 @@ class CliTest < Minitest::Test
     assert_includes(out, "files inspected")
   end
 
+  def test_config_flag
+    storage = make_file_system_storage(
+      ".theme-check.yml" => <<~YAML,
+        SyntaxError:
+          enabled: false
+      YAML
+    )
+
+    cli = ThemeCheck::Cli.new
+    out = capture(:stdout) do
+      assert_raises(ThemeCheck::Cli::Abort) do
+        cli.run([__dir__ + "/theme", "-C", storage.path(".theme-check.yml")])
+      end
+    end
+
+    assert_equal(storage.path('.theme-check.yml'), ThemeCheck::Config.last_loaded_config)
+    assert_includes(out, "files inspected")
+  end
+
   def test_check_with_category
     cli = ThemeCheck::Cli.new
     out = capture(:stdout) do


### PR DESCRIPTION
Fixes #211

```
$ head -n 16 /tmp/.theme-check.yml
root: src

require: []

ignore:
  - node_modules/*

AssetSizeCSS:
  enabled: true
  threshold_in_bytes: 1

ConvertIncludeToRender:
  enabled: false

LiquidTag:
  enabled: false
$ theme-check -C /tmp/.theme-check.yml ../path-to-project
Checking ../path-to-project/src ...
layout/theme.liquid:8: error: AssetSizeCSS: CSS on every page load exceding compressed size threshold (1 Bytes)..
        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384...
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

581 files inspected, 1 offenses detected, 0 offenses auto-correctable
```