### PR TITLE
Add Snippet Completion + Document Links

### DIFF
--- a/lib/theme_check/in_memory_storage.rb
+++ b/lib/theme_check/in_memory_storage.rb
@@ -6,20 +6,28 @@
 # as a big hash already, leave it like that and save yourself some IO.
 module ThemeCheck
   class InMemoryStorage < Storage
-    def initialize(files = {})
+    def initialize(files = {}, root = nil)
       @files = files
+      @root = root
     end
 
     def path(name)
+      return File.join(@root, name) unless @root.nil?
+      name
+    end
+
+    def relative_path(name)
+      path = Pathname.new(name)
+      return path.relative_path_from(@root).to_s unless path.relative? || @root.nil?
       name
     end
 
     def read(name)
-      @files[name]
+      @files[relative_path(name)]
     end
 
     def write(name, content)
-      @files[name] = content
+      @files[relative_path(name)] = content
     end
 
     def files

--- a/lib/theme_check/language_server.rb
+++ b/lib/theme_check/language_server.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require_relative "language_server/protocol"
+require_relative "language_server/constants"
 require_relative "language_server/handler"
 require_relative "language_server/server"
 require_relative "language_server/tokens"
@@ -7,6 +8,7 @@ require_relative "language_server/position_helper"
 require_relative "language_server/completion_helper"
 require_relative "language_server/completion_provider"
 require_relative "language_server/completion_engine"
+require_relative "language_server/document_link_engine"
 
 Dir[__dir__ + "/language_server/completion_providers/*.rb"].each do |file|
   require file

--- a/lib/theme_check/language_server/completion_engine.rb
+++ b/lib/theme_check/language_server/completion_engine.rb
@@ -7,7 +7,7 @@ module ThemeCheck
 
       def initialize(storage)
         @storage = storage
-        @providers = CompletionProvider.all.map(&:new)
+        @providers = CompletionProvider.all.map { |x| x.new(storage) }
       end
 
       def completions(name, line, col)

--- a/lib/theme_check/language_server/completion_provider.rb
+++ b/lib/theme_check/language_server/completion_provider.rb
@@ -16,6 +16,10 @@ module ThemeCheck
         end
       end
 
+      def initialize(storage = InMemoryStorage.new)
+        @storage = storage
+      end
+
       def completions(content, cursor)
         raise NotImplementedError
       end

--- a/lib/theme_check/language_server/completion_providers/render_snippet_completion_provider.rb
+++ b/lib/theme_check/language_server/completion_providers/render_snippet_completion_provider.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module ThemeCheck
+  module LanguageServer
+    class RenderSnippetCompletionProvider < CompletionProvider
+      def completions(content, cursor)
+        return [] unless cursor_on_quoted_argument?(content, cursor)
+        partial = snippet(content) || ''
+        snippets
+          .select { |x| x.starts_with?(partial) }
+          .map { |x| snippet_to_completion(x) }
+      end
+
+      private
+
+      def cursor_on_quoted_argument?(content, cursor)
+        match = content.match(PARTIAL_RENDER)
+        return false if match.nil?
+        match.begin(:partial) <= cursor && cursor <= match.end(:partial)
+      end
+
+      def snippet(content)
+        match = content.match(PARTIAL_RENDER)
+        return if match.nil?
+        match[:partial]
+      end
+
+      def snippets
+        @storage
+          .files
+          .select { |x| x.include?('snippets/') }
+      end
+
+      def snippet_to_completion(file)
+        {
+          label: File.basename(file, '.liquid'),
+          kind: CompletionItemKinds::SNIPPET,
+          detail: file,
+        }
+      end
+    end
+  end
+end

--- a/lib/theme_check/language_server/constants.rb
+++ b/lib/theme_check/language_server/constants.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module ThemeCheck
+  module LanguageServer
+    PARTIAL_RENDER = %r{
+      \{\%\s*render\s+'(?<partial>[^']*)'|
+      \{\%\s*render\s+"(?<partial>[^"]*)"
+    }mix
+  end
+end

--- a/lib/theme_check/language_server/document_link_engine.rb
+++ b/lib/theme_check/language_server/document_link_engine.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module ThemeCheck
+  module LanguageServer
+    class DocumentLinkEngine
+      include PositionHelper
+      include RegexHelpers
+
+      def initialize(storage)
+        @storage = storage
+      end
+
+      def document_links(uri)
+        buffer = @storage.read(uri)
+        matches(buffer, PARTIAL_RENDER).map do |match|
+          start_line, start_character = from_index_to_line_column(
+            buffer,
+            match.begin(:partial),
+          )
+
+          end_line, end_character = from_index_to_line_column(
+            buffer,
+            match.end(:partial)
+          )
+
+          {
+            target: link(match[:partial]),
+            range: {
+              start: {
+                line: start_line,
+                character: start_character,
+              },
+              end: {
+                line: end_line,
+                character: end_character,
+              },
+            },
+          }
+        end
+      end
+
+      def link(partial)
+        'file://' + @storage.path('snippets/' + partial + '.liquid')
+      end
+    end
+  end
+end

--- a/lib/theme_check/language_server/server.rb
+++ b/lib/theme_check/language_server/server.rb
@@ -16,7 +16,7 @@ module ThemeCheck
       def initialize(
         in_stream: STDIN,
         out_stream: STDOUT,
-        err_stream: $DEBUG ? File.open('/tmp/lsp.log', 'a') : STDERR,
+        err_stream: STDERR,
         should_raise_errors: false
       )
         validate!([in_stream, out_stream, err_stream])
@@ -51,7 +51,7 @@ module ThemeCheck
 
       def send_response(response)
         response_body = JSON.dump(response)
-        log(response_body) if $DEBUG
+        log(JSON.pretty_generate(response)) if $DEBUG
 
         @out.write("Content-Length: #{response_body.size}\r\n")
         @out.write("\r\n")

--- a/test/language_server/document_link_engine_test.rb
+++ b/test/language_server/document_link_engine_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module ThemeCheck
+  module LanguageServer
+    class DocumentLinkEngineTest < Minitest::Test
+      include PositionHelper
+
+      def test_makes_links_out_of_render_tags
+        content = <<~LIQUID
+          {% render 'a' %}
+          {% render "b" %}
+        LIQUID
+
+        engine = make_engine(
+          "snippets/a.liquid" => "",
+          "snippets/b.liquid" => "",
+          "templates/product.liquid" => content,
+        )
+
+        assert_links_include("a", content, engine.document_links("templates/product.liquid"))
+        assert_links_include("b", content, engine.document_links("templates/product.liquid"))
+      end
+
+      def assert_links_include(needle, content, links)
+        target = "file:///tmp/snippets/#{needle}.liquid"
+        match = links.find { |x| x[:target] == target }
+
+        refute_nil(match, "Should find a document_link with target == '#{target}'")
+
+        assert_equal(
+          from_index_to_line_column(content, content.index(needle)),
+          [
+            match.dig(:range, :start, :line),
+            match.dig(:range, :start, :character),
+          ],
+        )
+
+        assert_equal(
+          from_index_to_line_column(content, content.index(needle) + 1),
+          [
+            match.dig(:range, :end, :line),
+            match.dig(:range, :end, :character),
+          ],
+        )
+      end
+
+      private
+
+      def make_engine(files)
+        storage = InMemoryStorage.new(files, "/tmp")
+        DocumentLinkEngine.new(storage)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #180 

In this PR:

* Add `{% render '..' %}` completions
* Make snippets in `{% render '..' %}` clickable links

Demo: https://screenshot.click/23-09-71h84-pp23z.mp4
Also: https://screenshot.click/23-22-5tyee-kv5vl.mp4