### PR TITLE
Update & fix Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
-inherit_from:
-  - 'https://shopify.github.io/ruby-style-guide/rubocop.yml'
+inherit_gem:
+  rubocop-shopify: rubocop.yml
 
 require: rubocop-performance
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,10 @@
 inherit_gem:
   rubocop-shopify: rubocop.yml
 
-require: rubocop-performance
+require:
+  - rubocop-performance
+  - rubocop-minitest
+  - rubocop-rake
 
 AllCops:
   TargetRubyVersion: 2.7

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ group :development do
   gem 'guard-minitest'
 end
 
-gem 'rubocop', '~> 1.4', require: false
-gem 'rubocop-performance', '~> 1.10.2', require: false
-gem 'rubocop-shopify', '~> 1.0.7', require: false
+gem 'rubocop', require: false
+gem 'rubocop-performance', require: false
+gem 'rubocop-shopify', require: false
+gem 'rubocop-minitest', require: false
+gem 'rubocop-rake', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,6 @@ group :development do
   gem 'guard-minitest'
 end
 
-gem 'rubocop', '~> 0.93.1', require: false
-gem 'rubocop-performance', '~> 1.8.1', require: false
-gem 'rubocop-shopify', '~> 1.0.6', require: false
+gem 'rubocop', '~> 1.4', require: false
+gem 'rubocop-performance', '~> 1.10.2', require: false
+gem 'rubocop-shopify', '~> 1.0.7', require: false

--- a/lib/theme_check/language_server/server.rb
+++ b/lib/theme_check/language_server/server.rb
@@ -6,6 +6,7 @@ require 'active_support/core_ext/string/inflections'
 module ThemeCheck
   module LanguageServer
     class DoneStreaming < StandardError; end
+
     class IncompatibleStream < StandardError; end
 
     class Server


### PR DESCRIPTION
Use recommended way of installing rubocop-shopify.

Update to latest, w/ support for minitest & rake.