### PR TITLE
Pin Rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,8 @@ group :development do
   gem 'guard-minitest'
 end
 
-gem 'rubocop', require: false
-gem 'rubocop-performance', require: false
-gem 'rubocop-shopify', require: false
-gem 'rubocop-minitest', require: false
-gem 'rubocop-rake', require: false
+gem 'rubocop', '~> 1.12.0', require: false
+gem 'rubocop-performance', '~> 1.10.2', require: false
+gem 'rubocop-shopify', '~> 1.0.7', require: false
+gem 'rubocop-minitest', '~> 0.11.0', require: false
+gem 'rubocop-rake', '~> 0.5.1', require: false

--- a/lib/theme_check/checks/translation_key_exists.rb
+++ b/lib/theme_check/checks/translation_key_exists.rb
@@ -4,10 +4,7 @@ module ThemeCheck
     extend self
 
     def translations
-      @translations ||= begin
-        # loaded as a Set because the include? lookup will be much faster.
-        YAML.load(File.read("#{__dir__}/../../../data/shopify_translation_keys.yml")).to_set
-      end
+      @translations ||= YAML.load(File.read("#{__dir__}/../../../data/shopify_translation_keys.yml")).to_set
     end
 
     def include?(key)

--- a/lib/theme_check/shopify_liquid/deprecated_filter.rb
+++ b/lib/theme_check/shopify_liquid/deprecated_filter.rb
@@ -17,14 +17,12 @@ module ThemeCheck
       private
 
       def all
-        @all ||= begin
-          YAML.load(File.read("#{__dir__}/../../../data/shopify_liquid/deprecated_filters.yml"))
-            .values
-            .each_with_object({}) do |filters, acc|
-              filters.each do |(filter, alternatives)|
-                acc[filter] = alternatives
-              end
-            end
+        @all ||= YAML.load(File.read("#{__dir__}/../../../data/shopify_liquid/deprecated_filters.yml"))
+          .values
+          .each_with_object({}) do |filters, acc|
+          filters.each do |(filter, alternatives)|
+            acc[filter] = alternatives
+          end
         end
       end
     end

--- a/lib/theme_check/shopify_liquid/filter.rb
+++ b/lib/theme_check/shopify_liquid/filter.rb
@@ -7,11 +7,9 @@ module ThemeCheck
       extend self
 
       def labels
-        @labels ||= begin
-          YAML.load(File.read("#{__dir__}/../../../data/shopify_liquid/filters.yml"))
-            .values
-            .flatten
-        end
+        @labels ||= YAML.load(File.read("#{__dir__}/../../../data/shopify_liquid/filters.yml"))
+          .values
+          .flatten
       end
     end
   end

--- a/lib/theme_check/shopify_liquid/object.rb
+++ b/lib/theme_check/shopify_liquid/object.rb
@@ -7,15 +7,11 @@ module ThemeCheck
       extend self
 
       def labels
-        @labels ||= begin
-          YAML.load(File.read("#{__dir__}/../../../data/shopify_liquid/objects.yml"))
-        end
+        @labels ||= YAML.load(File.read("#{__dir__}/../../../data/shopify_liquid/objects.yml"))
       end
 
       def plus_labels
-        @plus_labels ||= begin
-          YAML.load(File.read("#{__dir__}/../../../data/shopify_liquid/plus_objects.yml"))
-        end
+        @plus_labels ||= YAML.load(File.read("#{__dir__}/../../../data/shopify_liquid/plus_objects.yml"))
       end
     end
   end

--- a/lib/theme_check/shopify_liquid/tag.rb
+++ b/lib/theme_check/shopify_liquid/tag.rb
@@ -7,9 +7,7 @@ module ThemeCheck
       extend self
 
       def labels
-        @tags ||= begin
-          YAML.load(File.read("#{__dir__}/../../../data/shopify_liquid/tags.yml"))
-        end
+        @tags ||= YAML.load(File.read("#{__dir__}/../../../data/shopify_liquid/tags.yml"))
       end
     end
   end


### PR DESCRIPTION
Since we don't commit the Gemfile.lock, CI sometimes use an earlier version of Rubocop and causes unrelated failures.