### PR TITLE
Fix document links from different root

### DIFF
--- a/lib/theme_check/file_system_storage.rb
+++ b/lib/theme_check/file_system_storage.rb
@@ -12,7 +12,7 @@ module ThemeCheck
     end
 
     def path(relative_path)
-      @root.join(relative_path)
+      @root.join(relative_path).to_s
     end
 
     def read(relative_path)

--- a/lib/theme_check/in_memory_storage.rb
+++ b/lib/theme_check/in_memory_storage.rb
@@ -6,32 +6,29 @@
 # as a big hash already, leave it like that and save yourself some IO.
 module ThemeCheck
   class InMemoryStorage < Storage
-    def initialize(files = {}, root = nil)
+    def initialize(files = {}, root = "/dev/null")
       @files = files
-      @root = root
+      @root = Pathname.new(root)
     end
 
-    def path(name)
-      return File.join(@root, name) unless @root.nil?
-      name
+    def path(relative_path)
+      @root.join(relative_path).to_s
     end
 
-    def relative_path(name)
-      path = Pathname.new(name)
-      return path.relative_path_from(@root).to_s unless path.relative? || @root.nil?
-      name
+    def relative_path(absolute_path)
+      Pathname.new(absolute_path).relative_path_from(@root).to_s
     end
 
-    def read(name)
-      @files[relative_path(name)]
+    def read(relative_path)
+      @files[relative_path]
     end
 
-    def write(name, content)
-      @files[relative_path(name)] = content
+    def write(relative_path, content)
+      @files[relative_path] = content
     end
 
     def files
-      @values ||= @files.keys
+      @files.keys
     end
 
     def directories

--- a/lib/theme_check/language_server/completion_engine.rb
+++ b/lib/theme_check/language_server/completion_engine.rb
@@ -10,8 +10,8 @@ module ThemeCheck
         @providers = CompletionProvider.all.map { |x| x.new(storage) }
       end
 
-      def completions(name, line, col)
-        buffer = @storage.read(name)
+      def completions(relative_path, line, col)
+        buffer = @storage.read(relative_path)
         cursor = from_line_column_to_index(buffer, line, col)
         token = find_token(buffer, cursor)
         return [] if token.nil?

--- a/lib/theme_check/language_server/document_link_engine.rb
+++ b/lib/theme_check/language_server/document_link_engine.rb
@@ -10,8 +10,9 @@ module ThemeCheck
         @storage = storage
       end
 
-      def document_links(uri)
-        buffer = @storage.read(uri)
+      def document_links(relative_path)
+        buffer = @storage.read(relative_path)
+        return [] unless buffer
         matches(buffer, PARTIAL_RENDER).map do |match|
           start_line, start_character = from_index_to_line_column(
             buffer,


### PR DESCRIPTION
Fixes #231

Had to refactor a little bit here. Made it clearer that the expected API for read/write on Storage is relative_paths. Also made it so the handler was properly using relative paths when calling the completion and document link engines.

Also:
- Added integration tests for document link (with/without root attribute)
- Refactored all the storage.root.join(...).to_s -> storage.path(...) in tests
- Also made the urls in diagnostics use `file://` instead of `file:`. Since I believe `file://` is the standard. (I'm being redirected in a browser anyway.)