### PR TITLE
Fixup .index(nil) in RemoteAsset

### DIFF
--- a/lib/theme_check/checks/remote_asset.rb
+++ b/lib/theme_check/checks/remote_asset.rb
@@ -76,6 +76,7 @@ module ThemeCheck
         next if url_hosted_by_shopify?(resource_url)
         next if resource_url =~ ABSOLUTE_PATH
         next if resource_url =~ RELATIVE_PATH
+        next if resource_url.empty?
 
         start = match.begin(0) + resource_match.begin(:resource_url)
         add_offense(

--- a/lib/theme_check/offense.rb
+++ b/lib/theme_check/offense.rb
@@ -32,6 +32,8 @@ module ThemeCheck
         node&.markup
       end
 
+      raise ArgumentError, "Offense markup cannot be an empty string" if @markup.is_a?(String) && @markup.empty?
+
       @line_number = if line_number
         line_number
       elsif @node

--- a/test/checks/remote_asset_test.rb
+++ b/test/checks/remote_asset_test.rb
@@ -35,6 +35,9 @@ module ThemeCheck
           {{ url | global_asset_url | script_tag }}
           {{ url | payment_type_img_url | img_tag }}
           {{ url | shopify_asset_url | img_tag }}
+
+          <!-- weird edge cases from the wild -->
+          <img alt="logo" src="" data-src="{{ url | asset_url | img_tag }}" width="100" height="100" />
         END
       )
       assert_offenses("", offenses)


### PR DESCRIPTION
Fixes #147

The check was tripping on <img src="" data-src="{{ img | img_url }}"> because the check's markup was an empty string.

In the Offense code, this meant the following:

- lines_of_content == []
- lines_of_content.first == nil
- full_line(line_number).index(lines_of_content.first) throws an error because .index(nil) is an implicit conversion of nil to string.

Ugh.

Fix:

- Don't report errors for <img src="">
- Report errors on the creation of the offense for a better error message + stack trace.