### PR TITLE
Rescue errors thrown by remote_asset_file

### DIFF
--- a/lib/theme_check.rb
+++ b/lib/theme_check.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "liquid"
 
+require_relative "theme_check/exceptions"
 require_relative "theme_check/analyzer"
 require_relative "theme_check/check"
 require_relative "theme_check/checks_tracking"

--- a/lib/theme_check/exceptions.rb
+++ b/lib/theme_check/exceptions.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require "net/http"
+
+TIMEOUT_EXCEPTIONS = [
+  Net::ReadTimeout,
+  Net::OpenTimeout,
+  Net::WriteTimeout,
+  Errno::ETIMEDOUT,
+  Timeout::Error,
+]
+
+CONNECTION_EXCEPTIONS = [
+  IOError,
+  EOFError,
+  SocketError,
+  Errno::EINVAL,
+  Errno::ECONNRESET,
+  Errno::ECONNABORTED,
+  Errno::EPIPE,
+  Errno::ECONNREFUSED,
+  Errno::EAGAIN,
+  Errno::EHOSTUNREACH,
+  Errno::ENETUNREACH,
+]
+
+NET_HTTP_EXCEPTIONS = [
+  Net::HTTPBadResponse,
+  Net::HTTPHeaderSyntaxError,
+  Net::ProtocolError,
+  *TIMEOUT_EXCEPTIONS,
+  *CONNECTION_EXCEPTIONS,
+]

--- a/lib/theme_check/remote_asset_file.rb
+++ b/lib/theme_check/remote_asset_file.rb
@@ -35,6 +35,9 @@ module ThemeCheck
       end
 
       @content = res.body
+
+    rescue OpenSSL::SSL::SSLError, Zlib::StreamError, *NET_HTTP_EXCEPTIONS
+      @contents = ''
     end
 
     def gzipped_size


### PR DESCRIPTION
Sometimes the size check doesn't work. It's OK to ignore them.