### PR TITLE
Handle LSP initialize with null rootPath + rootUri

### DIFF
--- a/test/language_server_test.rb
+++ b/test/language_server_test.rb
@@ -405,6 +405,26 @@ class LanguageServerTest < Minitest::Test
     })
   end
 
+  def test_handles_on_initialize_with_null_paths
+    send_messages({
+      "jsonrpc" => "2.0",
+      "id" => "123",
+      "method" => "initialize",
+      "params" => {
+        "rootPath" => nil,
+        "rootUri" => nil,
+      },
+    })
+
+    assert_responses({
+      "jsonrpc" => "2.0",
+      "id" => "123",
+      "result" => {
+        "capabilities" => {},
+      },
+    })
+  end
+
   private
 
   def send_messages(*messages)


### PR DESCRIPTION
Fixes #264

Also, I included a small refactor of send_response to fit the protocol spec. There are  [response messages](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#responseMessage) and there are [notification messages](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#notificationMessage). 

I added helper functions to make the distinction a bit clearer and simplify the calls.