### PR TITLE
Include operators to space inside braces check

### DIFF
--- a/docs/checks/space_inside_braces.md
+++ b/docs/checks/space_inside_braces.md
@@ -21,6 +21,10 @@ This check is aimed at eliminating ugly Liquid:
 <!-- Arround filter pipelines -->
 {{ url  | asset_url | img_tag }}
 {% assign my_upcase_string = "Hello world"| upcase %}
+
+<!-- Arround symbol operators -->
+{%- if target  == product and product.price_varies -%}
+{%- if product.featured_media.width >=165 -%}
 ```
 
 :+1: Examples of **correct** code for this check:
@@ -39,6 +43,8 @@ This check is aimed at eliminating ugly Liquid:
 %}
 {{ url | asset_url | img_tag }}
 {% assign my_upcase_string = "Hello world" | upcase %}
+{%- if target == product and product.price_varies -%}
+{%- if product.featured_media.width >= 165 -%}
 ```
 
 ## Check Options

--- a/lib/theme_check/checks/space_inside_braces.rb
+++ b/lib/theme_check/checks/space_inside_braces.rb
@@ -15,17 +15,17 @@ module ThemeCheck
       return if :assign == node.type_name
 
       outside_of_strings(node.markup) do |chunk|
-        chunk.scan(/([,:|])  +/) do |_match|
+        chunk.scan(/([,:|]|==|<>|<=|>=|<|>|!=)  +/) do |_match|
           add_offense("Too many spaces after '#{Regexp.last_match(1)}'", node: node, markup: Regexp.last_match(0))
         end
-        chunk.scan(/([,:|])\S/) do |_match|
+        chunk.scan(/([,:|]|==|<>|<=|>=|<\b|>\b|!=)(\S|\z)/) do |_match|
           add_offense("Space missing after '#{Regexp.last_match(1)}'", node: node, markup: Regexp.last_match(0))
         end
-        chunk.scan(/  ([|])+/) do |_match|
+        chunk.scan(/  (\||==|<>|<=|>=|<|>|!=)+/) do |_match|
           add_offense("Too many spaces before '#{Regexp.last_match(1)}'", node: node, markup: Regexp.last_match(0))
         end
-        chunk.scan(/\A(?<pipe>\|)|\S(?<pipe>\|)/) do |_match|
-          add_offense("Space missing before '#{Regexp.last_match(:pipe)}'", node: node, markup: Regexp.last_match(:pipe))
+        chunk.scan(/(\A|\S)(?<match>\||==|<>|<=|>=|<|\b>|!=)/) do |_match|
+          add_offense("Space missing before '#{Regexp.last_match(1)}'", node: node, markup: Regexp.last_match(0))
         end
       end
     end

--- a/test/checks/space_inside_braces_test.rb
+++ b/test/checks/space_inside_braces_test.rb
@@ -107,7 +107,7 @@ class SpaceInsideBracesTest < Minitest::Test
     END
   end
 
-  def test_dont_report_with_proper_spaces
+  def test_dont_report_on_proper_spaces_around_pipeline
     offenses = analyze_theme(
       ThemeCheck::SpaceInsideBraces.new,
       "templates/index.liquid" => <<~END,
@@ -170,5 +170,117 @@ class SpaceInsideBracesTest < Minitest::Test
     sources.each do |path, source|
       assert_equal(expected_sources[path], source)
     end
+  end
+
+  def test_reports_extra_space_after_operators
+    offenses = analyze_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {%- if x >  y -%}{%- endif -%}
+        {%- if x <  y -%}{%- endif -%}
+        {%- if x ==  "x" -%}{%- endif -%}
+        {%- if x !=  "x" -%}{%- endif -%}
+        {%- if x >=  y -%}{%- endif -%}
+        {%- if x <=  y -%}{%- endif -%}
+        {%- if x <>  y -%}{%- endif -%}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Too many spaces after '>' at templates/index.liquid:1
+      Too many spaces after '<' at templates/index.liquid:2
+      Too many spaces after '==' at templates/index.liquid:3
+      Too many spaces after '!=' at templates/index.liquid:4
+      Too many spaces after '>=' at templates/index.liquid:5
+      Too many spaces after '<=' at templates/index.liquid:6
+      Too many spaces after '<>' at templates/index.liquid:7
+    END
+  end
+
+  def test_reports_missing_space_after_operators
+    offenses = analyze_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {%- if x >y -%}{%- endif -%}
+        {%- if x <y -%}{%- endif -%}
+        {%- if x =="x" -%}{%- endif -%}
+        {%- if x !="x" -%}{%- endif -%}
+        {%- if x >=y -%}{%- endif -%}
+        {%- if x <=y -%}{%- endif -%}
+        {%- if x <>y -%}{%- endif -%}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Space missing after '>' at templates/index.liquid:1
+      Space missing after '<' at templates/index.liquid:2
+      Space missing after '==' at templates/index.liquid:3
+      Space missing after '!=' at templates/index.liquid:4
+      Space missing after '>=' at templates/index.liquid:5
+      Space missing after '<=' at templates/index.liquid:6
+      Space missing after '<>' at templates/index.liquid:7
+    END
+  end
+
+  def test_reports_extra_space_before_operators
+    offenses = analyze_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {%- if x  > y -%}{%- endif -%}
+        {%- if x  < y -%}{%- endif -%}
+        {%- if x  == "x" -%}{%- endif -%}
+        {%- if x  != "x" -%}{%- endif -%}
+        {%- if x  >= y -%}{%- endif -%}
+        {%- if x  <= y -%}{%- endif -%}
+        {%- if x  <> y -%}{%- endif -%}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Too many spaces before '>' at templates/index.liquid:1
+      Too many spaces before '<' at templates/index.liquid:2
+      Too many spaces before '==' at templates/index.liquid:3
+      Too many spaces before '!=' at templates/index.liquid:4
+      Too many spaces before '>=' at templates/index.liquid:5
+      Too many spaces before '<=' at templates/index.liquid:6
+      Too many spaces before '<>' at templates/index.liquid:7
+    END
+  end
+
+  def test_reports_missing_space_before_operators
+    offenses = analyze_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {%- if x> y -%}{%- endif -%}
+        {%- if x< y -%}{%- endif -%}
+        {%- if x== "x" -%}{%- endif -%}
+        {%- if x!= "x" -%}{%- endif -%}
+        {%- if x>= y -%}{%- endif -%}
+        {%- if x<= y -%}{%- endif -%}
+        {%- if x<> y -%}{%- endif -%}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Space missing before '>' at templates/index.liquid:1
+      Space missing before '<' at templates/index.liquid:2
+      Space missing before '==' at templates/index.liquid:3
+      Space missing before '!=' at templates/index.liquid:4
+      Space missing before '>=' at templates/index.liquid:5
+      Space missing before '<=' at templates/index.liquid:6
+      Space missing before '<>' at templates/index.liquid:7
+    END
+  end
+
+  def test_dont_report_with_correct_spaces_around_operators
+    offenses = analyze_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {%- if x > y -%}{%- endif -%}
+        {%- if x < y -%}{%- endif -%}
+        {%- if x == "x" -%}{%- endif -%}
+        {%- if x != "x" -%}{%- endif -%}
+        {%- if x >= y -%}{%- endif -%}
+        {%- if x <= y -%}{%- endif -%}
+        {%- if x <> y -%}{%- endif -%}
+      END
+    )
+    assert_offenses('', offenses)
   end
 end


### PR DESCRIPTION
From https://github.com/Shopify/theme-tools/issues/447

- Added: check for consistent spaces around symbol comparison and logical operators.
- Fixed: space after `:` was not accusing offense if the next character was a string quote.
- Fixed: markup on missing space before filter pipeline offense was only pointing to the pipe, and not to the complete match.
