### PR TITLE
Add a message to help debug errors, timeout after 5 sec of running a check

### DIFF
--- a/lib/theme_check.rb
+++ b/lib/theme_check.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "liquid"
 
+require_relative "theme_check/bug"
 require_relative "theme_check/exceptions"
 require_relative "theme_check/analyzer"
 require_relative "theme_check/check"

--- a/lib/theme_check/bug.rb
+++ b/lib/theme_check/bug.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ThemeCheck
+  BUG_POSTAMBLE = <<~EOS
+    Theme Check Version: #{VERSION}
+    Ruby Version: #{RUBY_VERSION}
+    Platform: #{RUBY_PLATFORM}
+    Muffin mode: activated
+
+    ------------------------
+    Whoops! It looks like you found a bug in Theme Check.
+    Please report it at https://github.com/Shopify/theme-check/issues, and include the message above.
+    Or cross your fingers real hard, and try again.
+  EOS
+
+  def self.bug(message)
+    abort(message + BUG_POSTAMBLE)
+  end
+end

--- a/lib/theme_check/checks.rb
+++ b/lib/theme_check/checks.rb
@@ -1,16 +1,52 @@
 # frozen_string_literal: true
+require "pp"
+require "timeout"
+
 module ThemeCheck
   class Checks < Array
+    CHECK_METHOD_TIMEOUT = 5 # sec
+
     def call(method, *args)
       each do |check|
-        if check.respond_to?(method) && !check.ignored?
-          check.send(method, *args)
-        end
+        call_check_method(check, method, *args)
       end
     end
 
     def disableable
       self.class.new(select(&:can_disable?))
+    end
+
+    private
+
+    def call_check_method(check, method, *args)
+      return unless check.respond_to?(method) && !check.ignored?
+
+      Timeout.timeout(CHECK_METHOD_TIMEOUT) do
+        check.send(method, *args)
+      end
+    rescue Liquid::Error
+      # Pass-through Liquid errors
+      raise
+    rescue => e
+      node = args.first
+      template = node.respond_to?(:template) ? node.template.relative_path : "?"
+      markup = node.respond_to?(:markup) ? node.markup : ""
+      node_class = node.respond_to?(:value) ? node.value.class : "?"
+
+      ThemeCheck.bug(<<~EOS)
+        Exception while running #{check.code_name}##{method}:
+
+          #{e.class}: #{e.message}
+            #{e.backtrace.join("\n    ")}
+
+        Template: #{template}
+        Node: #{node_class}
+        Markup:
+        ```
+        #{markup}
+        ```
+        Check options: #{check.options.pretty_inspect}
+      EOS
     end
   end
 end

--- a/lib/theme_check/checks.rb
+++ b/lib/theme_check/checks.rb
@@ -34,18 +34,19 @@ module ThemeCheck
       node_class = node.respond_to?(:value) ? node.value.class : "?"
 
       ThemeCheck.bug(<<~EOS)
-        Exception while running #{check.code_name}##{method}:
+        Exception while running `#{check.code_name}##{method}`:
+        ```
+        #{e.class}: #{e.message}
+          #{e.backtrace.join("\n  ")}
+        ```
 
-          #{e.class}: #{e.message}
-            #{e.backtrace.join("\n    ")}
-
-        Template: #{template}
-        Node: #{node_class}
+        Template: `#{template}`
+        Node: `#{node_class}`
         Markup:
         ```
         #{markup}
         ```
-        Check options: #{check.options.pretty_inspect}
+        Check options: `#{check.options.pretty_inspect}`
       EOS
     end
   end


### PR DESCRIPTION
Should help with debugging hangs, and other errors.

### Sample

Exception while running `UnusedAssign#on_assign`:
```
RuntimeError: ouch
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/checks/unused_assign.rb:32:in `on_assign'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/checks.rb:25:in `block in call_check_method'
  /opt/rubies/2.6.6/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
  /opt/rubies/2.6.6/lib/ruby/2.6.0/timeout.rb:33:in `block in catch'
  /opt/rubies/2.6.6/lib/ruby/2.6.0/timeout.rb:33:in `catch'
  /opt/rubies/2.6.6/lib/ruby/2.6.0/timeout.rb:33:in `catch'
  /opt/rubies/2.6.6/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/checks.rb:24:in `call_check_method'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/checks.rb:11:in `block in call'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/checks.rb:10:in `each'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/checks.rb:10:in `call'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/visitor.rb:36:in `call_checks'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/visitor.rb:24:in `visit'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/visitor.rb:25:in `block in visit'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/visitor.rb:25:in `each'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/visitor.rb:25:in `visit'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/visitor.rb:12:in `visit_template'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/analyzer.rb:41:in `block in analyze_theme'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/analyzer.rb:41:in `each'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/analyzer.rb:41:in `analyze_theme'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/cli.rb:157:in `check'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/cli.rb:97:in `run!'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/cli.rb:101:in `run'
  /Users/ma/src/github.com/Shopify/theme-check/lib/theme_check/cli.rb:119:in `parse_and_run'
  /Users/ma/src/github.com/Shopify/theme-check/exe/theme-check:6:in `<top (required)>'
  /Users/ma/.gem/ruby/2.6.6/bin/theme-check:23:in `load'
  /Users/ma/.gem/ruby/2.6.6/bin/theme-check:23:in `<top (required)>'
  /Users/ma/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `load'
  /Users/ma/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `kernel_load'
  /Users/ma/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:28:in `run'
  /Users/ma/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/cli.rb:476:in `exec'
  /Users/ma/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  /Users/ma/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
  /Users/ma/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
  /Users/ma/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/cli.rb:30:in `dispatch'
  /Users/ma/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
  /Users/ma/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/cli.rb:24:in `start'
  /Users/ma/.gem/ruby/2.6.6/gems/bundler-2.1.4/exe/bundle:46:in `block in <top (required)>'
  /Users/ma/.gem/ruby/2.6.6/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
  /Users/ma/.gem/ruby/2.6.6/gems/bundler-2.1.4/exe/bundle:34:in `<top (required)>'
  /Users/ma/.gem/ruby/2.6.6/bin/bundle:23:in `load'
  /Users/ma/.gem/ruby/2.6.6/bin/bundle:23:in `<main>'
```

Template: `snippets/product-card-placeholder.liquid`
Node: `Liquid::Assign`
Markup:
```
assign adapt_height = false
```
Check options: `{}
`
Theme Check Version: 0.8.1
Ruby Version: 2.6.6
Platform: x86_64-darwin19
Muffin mode: activated

------------------------
Whoops! It looks like you found a bug in Theme Check.
Please report it at https://github.com/Shopify/theme-check/issues, and include the message above.
Or cross your fingers real hard, and try again.