### PR TITLE
Making sure version is set before referencing it

### DIFF
--- a/lib/theme_check/bug.rb
+++ b/lib/theme_check/bug.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'theme_check/version'
 
 module ThemeCheck
   BUG_POSTAMBLE = <<~EOS


### PR DESCRIPTION
Fixes runtime issue when installed via Gem:
```
Traceback (most recent call last):
	8: from /Users/taylorsteiger/.rbenv/versions/2.7.2/bin/theme-check:23:in `<main>'
	7: from /Users/taylorsteiger/.rbenv/versions/2.7.2/bin/theme-check:23:in `load'
	6: from /Users/taylorsteiger/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/theme-check-0.8.2/exe/theme-check:4:in `<top (required)>'
	5: from /Users/taylorsteiger/.rbenv/versions/2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
	4: from /Users/taylorsteiger/.rbenv/versions/2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
	3: from /Users/taylorsteiger/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/theme-check-0.8.2/lib/theme_check.rb:4:in `<top (required)>'
	2: from /Users/taylorsteiger/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/theme-check-0.8.2/lib/theme_check.rb:4:in `require_relative'
	1: from /Users/taylorsteiger/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/theme-check-0.8.2/lib/theme_check/bug.rb:3:in `<top (required)>'
/Users/taylorsteiger/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/theme-check-0.8.2/lib/theme_check/bug.rb:5:in `<module:ThemeCheck>': uninitialized constant ThemeCheck::VERSION (NameError)
```