### PR TITLE
Fix disabling checks that emit offences in `on_end`

### DIFF
--- a/lib/theme_check/analyzer.rb
+++ b/lib/theme_check/analyzer.rb
@@ -19,7 +19,8 @@ module ThemeCheck
         end
       end
 
-      @visitor = Visitor.new(@liquid_checks)
+      @disabled_checks = DisabledChecks.new
+      @visitor = Visitor.new(@liquid_checks, @disabled_checks)
     end
 
     def offenses
@@ -42,6 +43,8 @@ module ThemeCheck
       @theme.json.each { |json_file| @json_checks.call(:on_file, json_file) }
       @liquid_checks.call(:on_end)
       @json_checks.call(:on_end)
+      @disabled_checks.remove_disabled_offenses(@liquid_checks)
+      @disabled_checks.remove_disabled_offenses(@json_checks)
       offenses
     end
 

--- a/lib/theme_check/disabled_check.rb
+++ b/lib/theme_check/disabled_check.rb
@@ -4,10 +4,11 @@
 # We'll use the node position to figure out if the test is disabled or not.
 module ThemeCheck
   class DisabledCheck
-    attr_reader :name, :ranges
+    attr_reader :name, :template, :ranges
     attr_accessor :first_line
 
-    def initialize(name)
+    def initialize(template, name)
+      @template = template
       @name = name
       @ranges = []
       @first_line = false
@@ -24,7 +25,8 @@ module ThemeCheck
     end
 
     def disabled?(index)
-      ranges.any? { |range| range.cover?(index) }
+      index == 0 && first_line ||
+        ranges.any? { |range| range.cover?(index) }
     end
 
     def last
@@ -33,7 +35,7 @@ module ThemeCheck
 
     def missing_end_index?
       return false if first_line && ranges.size == 1
-      last.end.nil?
+      last&.end.nil?
     end
   end
 end

--- a/lib/theme_check/visitor.rb
+++ b/lib/theme_check/visitor.rb
@@ -3,14 +3,13 @@ module ThemeCheck
   class Visitor
     attr_reader :checks
 
-    def initialize(checks)
+    def initialize(checks, disabled_checks)
       @checks = checks
+      @disabled_checks = disabled_checks
     end
 
     def visit_template(template)
-      @disabled_checks = DisabledChecks.new
       visit(Node.new(template.root, nil, template))
-      remove_disabled_offenses
     rescue Liquid::Error => exception
       exception.template_name = template.name
       call_checks(:on_error, exception)
@@ -34,14 +33,6 @@ module ThemeCheck
 
     def call_checks(method, *args)
       checks.call(method, *args)
-    end
-
-    def remove_disabled_offenses
-      checks.disableable.each do |check|
-        check.offenses.reject! do |offense|
-          @disabled_checks.disabled?(offense.code_name, offense.start_index)
-        end
-      end
     end
   end
 end

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 class VisitorTest < Minitest::Test
   def setup
     @tracer = TracerCheck.new
-    @visitor = ThemeCheck::Visitor.new(ThemeCheck::Checks.new([@tracer]))
+    @visitor = ThemeCheck::Visitor.new(ThemeCheck::Checks.new([@tracer]), ThemeCheck::DisabledChecks.new)
   end
 
   def test_assign


### PR DESCRIPTION
### Problem

Discovered while trying to disable `UndefinedObject`. It didn't work because this checks adds the offenses during `on_end`, at the end of analysis. And we kept the disabled checks per template.

### Solution

Share the same `DisabledChecks` instance across all templates.

Also fix support for disabling offenses without any position (`UnusedSnippet`).
