### PR TITLE
Catch some runtime errors in CI/CD

### DIFF
--- a/.github/workflows/theme-check.yml
+++ b/.github/workflows/theme-check.yml
@@ -34,3 +34,6 @@ jobs:
       run: bundle install --jobs=3 --retry=3 --path=vendor/bundle
     - name: Run tests
       run: bundle exec rake
+    - name: Test runtime
+      # Testing that runtime can execute, not testing the results themselves
+      run: bundle exec theme-check ./test/theme | grep -q "2 files inspected"

--- a/.github/workflows/theme-check.yml
+++ b/.github/workflows/theme-check.yml
@@ -36,4 +36,4 @@ jobs:
       run: bundle exec rake
     - name: Test runtime
       # Testing that runtime can execute, not testing the results themselves
-      run: bundle exec theme-check ./test/theme | grep -q "2 files inspected"
+      run: bundle exec theme-check ./test/theme | grep -q "files inspected"

--- a/lib/theme_check.rb
+++ b/lib/theme_check.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "liquid"
 
+require_relative "theme_check/version"
 require_relative "theme_check/bug"
 require_relative "theme_check/exceptions"
 require_relative "theme_check/analyzer"
@@ -35,6 +36,5 @@ require_relative "theme_check/template"
 require_relative "theme_check/theme"
 require_relative "theme_check/visitor"
 require_relative "theme_check/corrector"
-require_relative "theme_check/version"
 
 Dir[__dir__ + "/theme_check/checks/*.rb"].each { |file| require file }


### PR DESCRIPTION
Triggers an execution of the new Gem, on an empty theme, to catch basic runtime errors. This helps to enforce the expectations outlined in `CONTRIBUTING.md`, and was from discussed briefly in a previous [PR](https://github.com/Shopify/theme-check/pull/288).