### PR TITLE
Fix Content-Length in LSP responses to use bytesize

### DIFF
--- a/lib/theme_check/language_server/server.rb
+++ b/lib/theme_check/language_server/server.rb
@@ -52,7 +52,7 @@ module ThemeCheck
         response_body = JSON.dump(response)
         log(JSON.pretty_generate(response)) if $DEBUG
 
-        @out.write("Content-Length: #{response_body.size}\r\n")
+        @out.write("Content-Length: #{response_body.bytesize}\r\n")
         @out.write("\r\n")
         @out.write(response_body)
         @out.flush


### PR DESCRIPTION
`String#size` returns the number of characters, but `Content-Length` must be:

> The length of the content part in bytes.

Fixes #276

Might also explain some other weird bugs in VSCode.