### PR TITLE
Add ContentForHeaderModification check to prevent relying on the content of CFH

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -96,3 +96,6 @@ ImgWidthAndHeight:
 
 RemoteAsset:
   enabled: true
+
+ContentForHeaderModification:
+  enabled: true

--- a/docs/checks/content_for_header_modification.md
+++ b/docs/checks/content_for_header_modification.md
@@ -1,0 +1,42 @@
+# Do not depend on the content of `content_for_header` (`ContentForHeaderModification`)
+
+Do not rely on the content of `content_for_header` as it might change in the future, which could cause your Liquid code behavior to change.
+
+## Check Details
+
+:-1: Examples of **incorrect** code for this check:
+
+```liquid
+{% assign parts = content_for_header | split: ',' %}
+```
+
+:+1: Examples of **correct** code for this check:
+
+The only acceptable usage of `content_for_header` is:
+
+```liquid
+{{ content_for_header }}
+```
+
+## Check Options
+
+The default configuration for this check is the following:
+
+```yaml
+ContentForHeaderModification:
+  enabled: true
+```
+
+## Version
+
+This check has been introduced in Theme Check THEME_CHECK_VERSION.
+
+## Resources
+
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+- [`theme.liquid` template considerations][considerations]
+
+[codesource]: /lib/theme_check/checks/check_class_name.rb
+[docsource]: /docs/checks/check_class_name.md
+[considerations]: https://shopify.dev/docs/themes/theme-templates/theme-liquid#template-considerations

--- a/lib/theme_check/checks/content_for_header_modification.rb
+++ b/lib/theme_check/checks/content_for_header_modification.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+module ThemeCheck
+  class ContentForHeaderModification < LiquidCheck
+    severity :error
+    category :liquid
+    doc docs_url(__FILE__)
+
+    def initialize
+      @in_assign = false
+      @in_capture = false
+    end
+
+    def on_variable(node)
+      return unless node.value.name.is_a?(Liquid::VariableLookup)
+      return unless node.value.name.name == "content_for_header"
+
+      if @in_assign || @in_capture || node.value.filters.any?
+        add_offense(
+          "Do not rely on the content of `content_for_header`",
+          node: node,
+        )
+      end
+    end
+
+    def on_assign(_node)
+      @in_assign = true
+    end
+
+    def after_assign(_node)
+      @in_assign = false
+    end
+
+    def on_capture(_node)
+      @in_capture = true
+    end
+
+    def after_capture(_node)
+      @in_capture = false
+    end
+  end
+end

--- a/test/checks/content_for_header_modification_test.rb
+++ b/test/checks/content_for_header_modification_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class ContentForHeaderModificationTest < Minitest::Test
+  def test_reports_use_of_filter
+    offenses = analyze_theme(
+      ThemeCheck::ContentForHeaderModification.new,
+      "layout/theme.liquid" => <<~END,
+        {{ content_for_header | split: ',' }}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Do not rely on the content of `content_for_header` at layout/theme.liquid:1
+    END
+  end
+
+  def test_reports_assign
+    offenses = analyze_theme(
+      ThemeCheck::ContentForHeaderModification.new,
+      "layout/theme.liquid" => <<~END,
+        {% assign x = content_for_header %}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Do not rely on the content of `content_for_header` at layout/theme.liquid:1
+    END
+  end
+
+  def test_reports_capture
+    offenses = analyze_theme(
+      ThemeCheck::ContentForHeaderModification.new,
+      "layout/theme.liquid" => <<~END,
+        {% capture x %}
+          {{ content_for_header }}
+        {% endcapture %}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Do not rely on the content of `content_for_header` at layout/theme.liquid:2
+    END
+  end
+
+  def test_do_not_report_normal_use
+    offenses = analyze_theme(
+      ThemeCheck::ContentForHeaderModification.new,
+      "layout/theme.liquid" => <<~END,
+        {{ content_for_header }}
+      END
+    )
+    assert_offenses("", offenses)
+  end
+end


### PR DESCRIPTION
Fixes #295 