### PR TITLE
Fix TemplateLength counter not being reseted on each document

### DIFF
--- a/lib/theme_check/checks/template_length.rb
+++ b/lib/theme_check/checks/template_length.rb
@@ -8,6 +8,9 @@ module ThemeCheck
     def initialize(max_length: 200, exclude_schema: true)
       @max_length = max_length
       @exclude_schema = exclude_schema
+    end
+
+    def on_document(_node)
       @excluded_lines = 0
     end
 


### PR DESCRIPTION
Whoops! The check instance is shared across all templates, so the `@excluded_lines` counter just kept increasing all the time.