### PR TITLE
Introduce single-file and whole-theme checks & optimize analysis in LSP

### DIFF
--- a/lib/theme_check/analyzer.rb
+++ b/lib/theme_check/analyzer.rb
@@ -72,7 +72,7 @@ module ThemeCheck
         end
       end
 
-      @liquid_checks.call(:on_end)  
+      @liquid_checks.call(:on_end)
       @json_checks.call(:on_end)
 
       disabled_checks.remove_disabled_offenses(@liquid_checks)

--- a/lib/theme_check/check.rb
+++ b/lib/theme_check/check.rb
@@ -67,6 +67,13 @@ module ThemeCheck
         end
         defined?(@can_disable) ? @can_disable : true
       end
+
+      def single_file(single_file = nil)
+        unless single_file.nil?
+          @single_file = single_file
+        end
+        defined?(@single_file) ? @single_file : !method_defined?(:on_end)
+      end
     end
 
     def offenses
@@ -103,6 +110,18 @@ module ThemeCheck
 
     def can_disable?
       self.class.can_disable
+    end
+
+    def single_file?
+      self.class.single_file
+    end
+
+    def whole_theme?
+      !single_file?
+    end
+
+    def ==(other)
+      other.is_a?(Check) && code_name == other.code_name
     end
 
     def to_s

--- a/lib/theme_check/checks.rb
+++ b/lib/theme_check/checks.rb
@@ -13,7 +13,15 @@ module ThemeCheck
     end
 
     def disableable
-      self.class.new(select(&:can_disable?))
+      @disableable ||= self.class.new(select(&:can_disable?))
+    end
+
+    def whole_theme
+      @whole_theme ||= self.class.new(select(&:whole_theme?))
+    end
+
+    def single_file
+      @single_file ||= self.class.new(select(&:single_file?))
     end
 
     private

--- a/lib/theme_check/checks/missing_template.rb
+++ b/lib/theme_check/checks/missing_template.rb
@@ -5,6 +5,7 @@ module ThemeCheck
     severity :suggestion
     category :liquid
     doc docs_url(__FILE__)
+    single_file false
 
     def on_include(node)
       template = node.value.template_name_expr

--- a/lib/theme_check/json_file.rb
+++ b/lib/theme_check/json_file.rb
@@ -38,6 +38,14 @@ module ThemeCheck
       relative_path.sub_ext('').to_s
     end
 
+    def json?
+      true
+    end
+
+    def liquid?
+      false
+    end
+
     private
 
     def load!

--- a/lib/theme_check/language_server.rb
+++ b/lib/theme_check/language_server.rb
@@ -9,6 +9,7 @@ require_relative "language_server/completion_helper"
 require_relative "language_server/completion_provider"
 require_relative "language_server/completion_engine"
 require_relative "language_server/document_link_engine"
+require_relative "language_server/diagnostics_tracker"
 
 Dir[__dir__ + "/language_server/completion_providers/*.rb"].each do |file|
   require file

--- a/lib/theme_check/language_server/diagnostics_tracker.rb
+++ b/lib/theme_check/language_server/diagnostics_tracker.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module ThemeCheck
+  module LanguageServer
+    class DiagnosticsTracker
+      def initialize
+        @previously_reported_files = Set.new
+        @single_files_offenses = {}
+        @first_run = true
+      end
+
+      def first_run?
+        @first_run
+      end
+
+      def build_diagnostics(offenses, analyzed_files: nil)
+        reported_files = Set.new
+        new_single_file_offenses = {}
+
+        offenses.group_by(&:template).each do |template, template_offenses|
+          next unless template
+          reported_offenses = template_offenses
+          previous_offenses = @single_files_offenses[template.path]
+          if analyzed_files.nil? || analyzed_files.include?(template.path)
+            # We re-analyzed the file, so we know the template_offenses are update to date.
+            reported_single_file_offenses = reported_offenses.select(&:single_file?)
+            if reported_single_file_offenses.any?
+              new_single_file_offenses[template.path] = reported_single_file_offenses
+            end
+          elsif previous_offenses
+            # Merge in the previous ones, if some
+            reported_offenses |= previous_offenses
+          end
+          yield template.path, reported_offenses
+          reported_files << template.path
+        end
+
+        @single_files_offenses.each do |path, offenses|
+          # Already reported above, skip
+          next if reported_files.include?(path)
+
+          if analyzed_files.nil? || analyzed_files.include?(path)
+            # We re-analyzed this file, if it was not reported, all offenses in it got fixed
+            yield path, []
+            new_single_file_offenses[path] = nil
+          end
+          # NOTE: No need to re-report previous offenses as LSP should keep them around until
+          # we clear them.
+          reported_files << path
+        end
+
+        # Publish diagnostics with empty array if all issues on a previously reported template
+        # have been fixed.
+        (@previously_reported_files - reported_files).each do |path|
+          yield path, []
+        end
+
+        @previously_reported_files = reported_files
+        @single_files_offenses.merge!(new_single_file_offenses)
+        @first_run = false
+      end
+    end
+  end
+end

--- a/lib/theme_check/language_server/diagnostics_tracker.rb
+++ b/lib/theme_check/language_server/diagnostics_tracker.rb
@@ -35,7 +35,7 @@ module ThemeCheck
           reported_files << template.path
         end
 
-        @single_files_offenses.each do |path, offenses|
+        @single_files_offenses.each do |path, _|
           # Already reported above, skip
           next if reported_files.include?(path)
 

--- a/lib/theme_check/language_server/handler.rb
+++ b/lib/theme_check/language_server/handler.rb
@@ -141,6 +141,7 @@ module ThemeCheck
           # Analyze selected files
           relative_path = Pathname.new(@storage.relative_path(absolute_path))
           file = theme[relative_path]
+          # Skip if not a theme file
           if file
             log("Checking #{relative_path}")
             offenses = nil
@@ -149,8 +150,6 @@ module ThemeCheck
             end
             log("Found #{offenses.size} new offenses in #{format("%0.2f", time.real)}s")
             send_diagnostics(offenses, [absolute_path])
-          else
-            # Not a theme file, skipping
           end
         end
       end
@@ -164,8 +163,8 @@ module ThemeCheck
       end
 
       def send_diagnostics(offenses, analyzed_files = nil)
-        @diagnostics_tracker.build_diagnostics(offenses, analyzed_files: analyzed_files) do |path, offenses|
-          send_diagnostic(path, offenses)
+        @diagnostics_tracker.build_diagnostics(offenses, analyzed_files: analyzed_files) do |path, diagnostic_offenses|
+          send_diagnostic(path, diagnostic_offenses)
         end
       end
 

--- a/lib/theme_check/offense.rb
+++ b/lib/theme_check/offense.rb
@@ -114,6 +114,24 @@ module ThemeCheck
       end
     end
 
+    def whole_theme?
+      check.whole_theme?
+    end
+
+    def single_file?
+      check.single_file?
+    end
+
+    def ==(other)
+      other.is_a?(Offense) &&
+        check == other.check &&
+        message == other.message &&
+        template == other.template &&
+        node == other.node &&
+        markup == other.markup &&
+        line_number == other.line_number
+    end
+
     def to_s
       if template
         "#{message} at #{location}"

--- a/lib/theme_check/template.rb
+++ b/lib/theme_check/template.rb
@@ -32,6 +32,14 @@ module ThemeCheck
       relative_path.sub_ext('').to_s
     end
 
+    def json?
+      false
+    end
+
+    def liquid?
+      true
+    end
+
     def template?
       name.start_with?('templates')
     end

--- a/lib/theme_check/theme.rb
+++ b/lib/theme_check/theme.rb
@@ -52,8 +52,13 @@ module ThemeCheck
       @all ||= json + liquid + assets
     end
 
-    def [](name)
-      all.find { |t| t.name == name }
+    def [](name_or_relative_path)
+      case name_or_relative_path
+      when Pathname
+        all.find { |t| t.relative_path == name_or_relative_path }
+      else
+        all.find { |t| t.name == name_or_relative_path }
+      end
     end
 
     def templates

--- a/test/language_server/diagnostics_tracker_test.rb
+++ b/test/language_server/diagnostics_tracker_test.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module ThemeCheck
+  module LanguageServer
+    class DiagnosticsTrackerTest < Minitest::Test
+      Offense = Struct.new(
+        :code_name,
+        :template,
+        :whole_theme?,
+      ) do
+        def single_file?
+          !whole_theme?
+        end
+
+        def inspect
+          "#<#{code_name} template=\"#{template.path}\" #{whole_theme? ? 'whole_theme' : 'single_file'}>"
+        end
+      end
+      Template = Struct.new(:path)
+
+      class WholeThemeOffense < Offense
+        def initialize(code_name, path)
+          super(code_name, Template.new(path), true)
+        end
+      end
+
+      class SingleFileOffense < Offense
+        def initialize(code_name, path)
+          super(code_name, Template.new(path), false)
+        end
+      end
+
+      def setup
+        @tracker = DiagnosticsTracker.new
+      end
+
+      def test_reports_all_on_first_run
+        assert_diagnostics(
+          offenses: [
+            WholeThemeOffense.new("MissingTemplate", "template/index.liquid"),
+            SingleFileOffense.new("UnusedAssign", "template/index.liquid"),
+            SingleFileOffense.new("UnusedAssign", "template/collection.liquid"),
+          ],
+          analyzed_files: [
+            "template/index.liquid",
+            "template/collection.liquid",
+          ],
+          diagnostics: {
+            "template/index.liquid" => [
+              WholeThemeOffense.new("MissingTemplate", "template/index.liquid"),
+              SingleFileOffense.new("UnusedAssign", "template/index.liquid"),
+            ],
+            "template/collection.liquid" => [
+              SingleFileOffense.new("UnusedAssign", "template/collection.liquid"),
+            ],
+          },
+        )
+      end
+
+      def test_reports_empty_when_offenses_are_fixed_in_subsequent_calls
+        build_diagnostics(
+          offenses: [
+            SingleFileOffense.new("UnusedAssign", "template/index.liquid"),
+            SingleFileOffense.new("UnknownFilter", "template/index.liquid"),
+            SingleFileOffense.new("UnusedAssign", "template/collection.liquid"),
+          ],
+        )
+        assert_diagnostics(
+          offenses: [
+            SingleFileOffense.new("UnusedAssign", "template/collection.liquid"),
+          ],
+          analyzed_files: [
+            "template/index.liquid",
+            "template/collection.liquid",
+          ],
+          diagnostics: {
+            "template/index.liquid" => [],
+            "template/collection.liquid" => [
+              SingleFileOffense.new("UnusedAssign", "template/collection.liquid"),
+            ],
+          },
+        )
+        assert_diagnostics(
+          offenses: [],
+          analyzed_files: [
+            "template/collection.liquid",
+          ],
+          diagnostics: {
+            "template/collection.liquid" => [],
+          },
+        )
+      end
+
+      def test_include_single_file_offenses_of_previous_runs
+        build_diagnostics(
+          offenses: [
+            SingleFileOffense.new("UnusedAssign", "template/index.liquid"),
+          ],
+        )
+        assert_diagnostics(
+          offenses: [
+            WholeThemeOffense.new("MissingTemplate", "template/index.liquid"),
+            SingleFileOffense.new("UnusedAssign", "template/collection.liquid"),
+          ],
+          analyzed_files: [
+            "template/collection.liquid",
+          ],
+          diagnostics: {
+            "template/index.liquid" => [
+              WholeThemeOffense.new("MissingTemplate", "template/index.liquid"),
+              SingleFileOffense.new("UnusedAssign", "template/index.liquid"),
+            ],
+            "template/collection.liquid" => [
+              SingleFileOffense.new("UnusedAssign", "template/collection.liquid"),
+            ],
+          },
+        )
+      end
+
+      def test_clears_whole_theme_offenses_from_previous_runs
+        build_diagnostics(
+          offenses: [
+            WholeThemeOffense.new("MissingTemplate", "template/index.liquid"),
+          ],
+        )
+        assert_diagnostics(
+          offenses: [
+            SingleFileOffense.new("UnusedAssign", "template/collection.liquid"),
+          ],
+          analyzed_files: [
+            "template/collection.liquid",
+          ],
+          diagnostics: {
+            "template/index.liquid" => [],
+            "template/collection.liquid" => [
+              SingleFileOffense.new("UnusedAssign", "template/collection.liquid"),
+            ],
+          },
+        )
+      end
+
+      private
+
+      def build_diagnostics(offenses:, analyzed_files: nil)
+        actual_diagnostics = {}
+        @tracker.build_diagnostics(offenses, analyzed_files: analyzed_files) do |path, offenses|
+          actual_diagnostics[path] = offenses
+        end
+        actual_diagnostics
+      end
+
+      def assert_diagnostics(offenses:, analyzed_files:, diagnostics:)
+        actual_diagnostics = build_diagnostics(offenses: offenses, analyzed_files: analyzed_files)
+        assert_equal(diagnostics, actual_diagnostics)
+      end
+    end
+  end
+end

--- a/test/language_server/diagnostics_tracker_test.rb
+++ b/test/language_server/diagnostics_tracker_test.rb
@@ -144,8 +144,8 @@ module ThemeCheck
 
       def build_diagnostics(offenses:, analyzed_files: nil)
         actual_diagnostics = {}
-        @tracker.build_diagnostics(offenses, analyzed_files: analyzed_files) do |path, offenses|
-          actual_diagnostics[path] = offenses
+        @tracker.build_diagnostics(offenses, analyzed_files: analyzed_files) do |path, diagnostic_offenses|
+          actual_diagnostics[path] = diagnostic_offenses
         end
         actual_diagnostics
       end

--- a/test/offense_test.rb
+++ b/test/offense_test.rb
@@ -130,4 +130,9 @@ class OffenseTest < Minitest::Test
     assert_equal(0, offense.start_column)
     assert_equal(3, offense.end_column)
   end
+
+  def test_equal
+    assert_equal(ThemeCheck::Offense.new(check: Bogus.new), ThemeCheck::Offense.new(check: Bogus.new))
+    refute_equal(ThemeCheck::Offense.new(check: Bogus.new), ThemeCheck::Offense.new(check: Bogus.new, markup: "nope"))
+  end
 end


### PR DESCRIPTION
A check is "single-file" if it only depends on the content of a single file.
A check is "whole-theme" if it depends on the content other files in the theme.

By default, a check will be single-file, unless it defines the `on_end` callback method. Because this implies that it depends on other files in the theme.

A check can be explicitly set as whole-theme with:

```ruby
class MissingTemplate < LiquidCheck
    # ...
    single_file false
end
```

### So what?

With this new concept introduced, we can optimize theme analysis in LSP.

In the context of LSP, we don't need to re-run single-file checks for files that haven't changed.

When we get a `textDocument/didSave`, the following happens:
- On first run: analyze the full theme like before
- On subsequent runs:
    1. Run all whole-theme checks
    2. Run all single-theme checks, but only on that modified document
    3. Merge LSP diagnostics with previous ones and send them

Also, this PR skips analysis on `textDocument/didOpen`, except on the first one.

### Benchmark

The first time you open a document, it will do a full theme analysis, like before, no improvements there:

```
Checking /Users/ma/src/github.com/Shopify/dawn
Found 35 offenses in 1.34s
```

Next time a document is saved, only that document will be scanned, along w/ whole-theme checks:

```
Checking sections/footer.liquid
Found 19 new offenses in 0.40s
```

About 3.4x faster.

This in addition to not running checks on document open should fix #147, and make it much faster in general.