### PR TITLE
Introduce HTML checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,8 @@ Under `lib/theme_check/checks`, create new Ruby file with a unique name describi
 ```ruby
 module ThemeCheck
   # Does one thing, and does it well!
-  # NOTE: inherit from JsonCheck to implement a JSON based check.
+  # NOTE: inherit from `JsonCheck` to implement a JSON-based check, and from `HtmlCheck`
+  # to implement an HTML-based one. See other checks in `lib/theme_check/checks` for examples.
   class MyCheckName < LiquidCheck
     severity :suggestion # :error or :style
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -107,6 +107,9 @@ ParserBlockingJavaScript:
   enabled: true
   ignore: []
 
+ParserBlockingScriptTag:
+  enabled: true
+
 AssetSizeJavaScript:
   enabled: false
   ignore: []

--- a/docs/checks/parser_blocking_script_tag.md
+++ b/docs/checks/parser_blocking_script_tag.md
@@ -1,0 +1,53 @@
+# Discourage use of parser-blocking `script_tag` filter (`ParserBlockingScriptTag`)
+
+The `script_tag` filter emits a parser-blocking script tag.
+
+See the [ParserBlockingJavaScript check documentation][parser_blocking_javascript] for why this is generally discouraged.
+
+## Check Details
+
+This check is aimed at eliminating parser-blocking JavaScript on themes.
+
+:-1: Examples of **incorrect** code for this check:
+
+```liquid
+<!-- The script_tag filter outputs a parser-blocking script -->
+{{ 'app-code.js' | asset_url | script_tag }}
+```
+
+:+1: Examples of **correct** code for this check:
+
+```liquid
+<!-- Good. Using the asset_url filter + defer -->
+<script src="{{ 'theme.js' | asset_url }}" defer></script>
+
+<!-- Also good. Using the asset_url filter + async -->
+<script src="{{ 'theme.js' | asset_url }}" async></script>
+```
+
+## Check Options
+
+The default configuration for this check is the following:
+
+```yaml
+ParserBlockingScriptTag:
+  enabled: true
+```
+
+## When Not To Use It
+
+This should only be turned off with the `theme-check-disable` comment when there's no better way to accomplish what you're doing than with a parser-blocking script.
+
+It is discouraged to turn this rule off.
+
+## Version
+
+This check has been introduced in Theme Check THEME_CHECK_VERSION.
+
+## Resources
+
+- [ParserBlockingJavaScript check][parser_blocking_javascript]
+- [Documentation Source][docsource]
+
+[parser_blocking_javascript]: /docs/checks/parser_blocking_javascript.md
+[docsource]: /docs/checks/parser_blocking_script_tag.md

--- a/lib/theme_check.rb
+++ b/lib/theme_check.rb
@@ -36,6 +36,9 @@ require_relative "theme_check/template"
 require_relative "theme_check/theme"
 require_relative "theme_check/visitor"
 require_relative "theme_check/corrector"
+require_relative "theme_check/html_node"
+require_relative "theme_check/html_visitor"
+require_relative "theme_check/html_check"
 
 Dir[__dir__ + "/theme_check/checks/*.rb"].each { |file| require file }
 

--- a/lib/theme_check/analyzer.rb
+++ b/lib/theme_check/analyzer.rb
@@ -21,7 +21,6 @@ module ThemeCheck
           @html_checks << check
         end
       end
-
     end
 
     def offenses

--- a/lib/theme_check/analyzer.rb
+++ b/lib/theme_check/analyzer.rb
@@ -7,6 +7,7 @@ module ThemeCheck
 
       @liquid_checks = Checks.new
       @json_checks = Checks.new
+      @html_checks = Checks.new
 
       checks.each do |check|
         check.theme = @theme
@@ -16,19 +17,29 @@ module ThemeCheck
           @liquid_checks << check
         when JsonCheck
           @json_checks << check
+        when HtmlCheck
+          @html_checks << check
         end
       end
+
     end
 
     def offenses
-      @liquid_checks.flat_map(&:offenses) + @json_checks.flat_map(&:offenses)
+      @liquid_checks.flat_map(&:offenses) +
+        @json_checks.flat_map(&:offenses) +
+        @html_checks.flat_map(&:offenses)
     end
 
     def analyze_theme
       reset
 
-      visitor = Visitor.new(@liquid_checks, @disabled_checks)
-      @theme.liquid.each { |template| visitor.visit_template(template) }
+      liquid_visitor = Visitor.new(@liquid_checks, @disabled_checks)
+      html_visitor = HtmlVisitor.new(@html_checks)
+      @theme.liquid.each do |template|
+        liquid_visitor.visit_template(template)
+        html_visitor.visit_template(template)
+      end
+
       @theme.json.each { |json_file| @json_checks.call(:on_file, json_file) }
 
       finish
@@ -38,15 +49,21 @@ module ThemeCheck
       reset
 
       # Call all checks that run on the whole theme
-      visitor = Visitor.new(@liquid_checks.whole_theme, @disabled_checks)
-      @theme.liquid.each { |template| visitor.visit_template(template) }
+      liquid_visitor = Visitor.new(@liquid_checks.whole_theme, @disabled_checks)
+      html_visitor = HtmlVisitor.new(@html_checks.whole_theme)
+      @theme.liquid.each do |template|
+        liquid_visitor.visit_template(template)
+        html_visitor.visit_template(template)
+      end
       @theme.json.each { |json_file| @json_checks.whole_theme.call(:on_file, json_file) }
 
       # Call checks that run on a single files, only on specified file
-      visitor = Visitor.new(@liquid_checks.single_file, @disabled_checks)
+      liquid_visitor = Visitor.new(@liquid_checks.single_file, @disabled_checks)
+      html_visitor = HtmlVisitor.new(@html_checks.single_file)
       files.each do |file|
         if file.liquid?
-          visitor.visit_template(file)
+          liquid_visitor.visit_template(file)
+          html_visitor.visit_template(file)
         elsif file.json?
           @json_checks.single_file.call(:on_file, file)
         end
@@ -79,6 +96,10 @@ module ThemeCheck
         check.offenses.clear
       end
 
+      @html_checks.each do |check|
+        check.offenses.clear
+      end
+
       @json_checks.each do |check|
         check.offenses.clear
       end
@@ -86,10 +107,12 @@ module ThemeCheck
 
     def finish
       @liquid_checks.call(:on_end)
+      @html_checks.call(:on_end)
       @json_checks.call(:on_end)
 
       @disabled_checks.remove_disabled_offenses(@liquid_checks)
       @disabled_checks.remove_disabled_offenses(@json_checks)
+      @disabled_checks.remove_disabled_offenses(@html_checks)
 
       offenses
     end

--- a/lib/theme_check/check.rb
+++ b/lib/theme_check/check.rb
@@ -19,6 +19,7 @@ module ThemeCheck
       :liquid,
       :translation,
       :performance,
+      :html,
       :json,
       :performance,
     ]
@@ -78,6 +79,10 @@ module ThemeCheck
 
     def offenses
       @offenses ||= []
+    end
+
+    def add_offense(message, node: nil, template: node&.template, markup: nil, line_number: nil, &block)
+      offenses << Offense.new(check: self, message: message, template: template, node: node, markup: markup, line_number: line_number, correction: block)
     end
 
     def severity

--- a/lib/theme_check/checks/img_width_and_height.rb
+++ b/lib/theme_check/checks/img_width_and_height.rb
@@ -1,41 +1,21 @@
 # frozen_string_literal: true
 module ThemeCheck
   # Reports errors when trying to use parser-blocking script tags
-  class ImgWidthAndHeight < LiquidCheck
-    include RegexHelpers
+  class ImgWidthAndHeight < HtmlCheck
     severity :error
-    categories :liquid, :performance
+    categories :html, :performance
     doc docs_url(__FILE__)
 
-    # Not implemented with lookbehinds and lookaheads because performance was shit!
-    IMG_TAG = %r{<img#{HTML_ATTRIBUTES}/?>}oxim
-    SRC_ATTRIBUTE = /\s(src)=(#{QUOTED_LIQUID_ATTRIBUTE})/oxim
-    WIDTH_ATTRIBUTE = /\s(width)=(#{QUOTED_LIQUID_ATTRIBUTE})/oxim
-    HEIGHT_ATTRIBUTE = /\s(height)=(#{QUOTED_LIQUID_ATTRIBUTE})/oxim
-
-    FIELDS = [WIDTH_ATTRIBUTE, HEIGHT_ATTRIBUTE]
     ENDS_IN_CSS_UNIT = /(cm|mm|in|px|pt|pc|em|ex|ch|rem|vw|vh|vmin|vmax|%)$/i
 
-    def on_document(node)
-      @source = node.template.source
-      @node = node
-      record_offenses
-    end
+    def on_img(node)
+      width = node.attributes["width"]&.value
+      height = node.attributes["height"]&.value
 
-    private
+      record_units_in_field_offenses("width", width, node: node)
+      record_units_in_field_offenses("height", height, node: node)
 
-    def record_offenses
-      matches(@source, IMG_TAG).each do |img_match|
-        next unless img_match[0] =~ SRC_ATTRIBUTE
-        record_missing_field_offenses(img_match)
-        record_units_in_field_offenses(img_match)
-      end
-    end
-
-    def record_missing_field_offenses(img_match)
-      width = WIDTH_ATTRIBUTE.match(img_match[0])
-      height = HEIGHT_ATTRIBUTE.match(img_match[0])
-      return if width && height
+      return if node.attributes["src"].nil? || (width && height)
       missing_width = width.nil?
       missing_height = height.nil?
       error_message = if missing_width && missing_height
@@ -46,29 +26,18 @@ module ThemeCheck
         "Missing height attribute"
       end
 
-      add_offense(
-        error_message,
-        node: @node,
-        markup: img_match[0],
-        line_number: @source[0...img_match.begin(0)].count("\n") + 1
-      )
+      add_offense(error_message, node: node)
     end
 
-    def record_units_in_field_offenses(img_match)
-      FIELDS.each do |field|
-        field_match = field.match(img_match[0])
-        next if field_match.nil?
-        value = field_match[2].gsub(START_OR_END_QUOTE, '')
-        next unless value =~ ENDS_IN_CSS_UNIT
-        value_without_units = value.gsub(ENDS_IN_CSS_UNIT, '')
-        start = img_match.begin(0) + field_match.begin(2)
-        add_offense(
-          "The #{field_match[1]} attribute does not take units. Replace with \"#{value_without_units}\".",
-          node: @node,
-          markup: value,
-          line_number: @source[0...start].count("\n") + 1
-        )
-      end
+    private
+
+    def record_units_in_field_offenses(attribute, value, node:)
+      return unless value =~ ENDS_IN_CSS_UNIT
+      value_without_units = value.gsub(ENDS_IN_CSS_UNIT, '')
+      add_offense(
+        "The #{attribute} attribute does not take units. Replace with \"#{value_without_units}\".",
+        node: node,
+      )
     end
   end
 end

--- a/lib/theme_check/checks/parser_blocking_javascript.rb
+++ b/lib/theme_check/checks/parser_blocking_javascript.rb
@@ -1,48 +1,16 @@
 # frozen_string_literal: true
 module ThemeCheck
   # Reports errors when trying to use parser-blocking script tags
-  class ParserBlockingJavaScript < LiquidCheck
-    include RegexHelpers
+  class ParserBlockingJavaScript < HtmlCheck
     severity :error
-    categories :liquid, :performance
+    categories :html, :performance
     doc docs_url(__FILE__)
 
-    PARSER_BLOCKING_SCRIPT_TAG = %r{
-      <script                                    # Find the start of a script tag
-      (?=[^>]+?src=)                             # Make sure src= is in the script with a lookahead
-      (?:(?!defer|async|type=["']module['"]).)*? # Find tags that don't have defer|async|type="module"
-      /?>
-    }xim
-    SCRIPT_TAG_FILTER = /\{\{[^}]+script_tag\s+\}\}/
+    def on_script(node)
+      return unless node.attributes["src"]
+      return if node.attributes["defer"] || node.attributes["async"] || node.attributes["type"]&.value == "module"
 
-    def on_document(node)
-      @source = node.template.source
-      @node = node
-      record_offenses
-    end
-
-    private
-
-    def record_offenses
-      record_offenses_from_regex(
-        message: "Missing async or defer attribute on script tag",
-        regex: PARSER_BLOCKING_SCRIPT_TAG,
-      )
-      record_offenses_from_regex(
-        message: "The script_tag filter is parser-blocking. Use a script tag with the async or defer attribute for better performance",
-        regex: SCRIPT_TAG_FILTER,
-      )
-    end
-
-    def record_offenses_from_regex(regex: nil, message: nil)
-      matches(@source, regex).each do |match|
-        add_offense(
-          message,
-          node: @node,
-          markup: match[0],
-          line_number: @source[0...match.begin(0)].count("\n") + 1
-        )
-      end
+      add_offense("Missing async or defer attribute on script tag", node: node)
     end
   end
 end

--- a/lib/theme_check/checks/parser_blocking_script_tag.rb
+++ b/lib/theme_check/checks/parser_blocking_script_tag.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module ThemeCheck
+  # Reports errors when trying to use parser-blocking script tags
+  class ParserBlockingScriptTag < LiquidCheck
+    severity :error
+    categories :liquid, :performance
+    doc docs_url(__FILE__)
+
+    def on_variable(node)
+      used_filters = node.value.filters.map { |name, *_rest| name }
+      if used_filters.include?("script_tag")
+        add_offense(
+          "The script_tag filter is parser-blocking. Use a script tag with the async or defer " \
+          "attribute for better performance",
+          node: node
+        )
+      end
+    end
+  end
+end

--- a/lib/theme_check/html_check.rb
+++ b/lib/theme_check/html_check.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module ThemeCheck
+  class HtmlCheck < Check
+    extend ChecksTracking
+  end
+end

--- a/lib/theme_check/html_node.rb
+++ b/lib/theme_check/html_node.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require "forwardable"
+
+module ThemeCheck
+  class HtmlNode
+    extend Forwardable
+    attr_reader :template
+
+    def_delegators :@value, :content, :attributes
+
+    def initialize(value, template)
+      @value = value
+      @template = template
+    end
+
+    def literal?
+      @value.name == "text"
+    end
+
+    def children
+      @value.children.map { |child| HtmlNode.new(child, template) }
+    end
+
+    def parent
+      HtmlNode.new(@value.parent, template)
+    end
+
+    def name
+      if @value.name == "#document-fragment"
+        "document"
+      else
+        @value.name
+      end
+    end
+
+    def value
+      if literal?
+        @value.content
+      else
+        @value
+      end
+    end
+
+    def markup
+      @value.to_html
+    end
+
+    def line_number
+      @value.line
+    end
+  end
+end

--- a/lib/theme_check/liquid_check.rb
+++ b/lib/theme_check/liquid_check.rb
@@ -16,9 +16,5 @@ module ThemeCheck
     ATTR = /[a-z0-9-]+/i
     HTML_ATTRIBUTE = /#{ATTR}(?:=#{QUOTED_LIQUID_ATTRIBUTE})?/omix
     HTML_ATTRIBUTES = /(?:#{HTML_ATTRIBUTE}|\s)*/omix
-
-    def add_offense(message, node: nil, template: node&.template, markup: nil, line_number: nil, &block)
-      offenses << Offense.new(check: self, message: message, template: template, node: node, markup: markup, line_number: line_number, correction: block)
-    end
   end
 end

--- a/test/checks/img_width_and_height_test.rb
+++ b/test/checks/img_width_and_height_test.rb
@@ -26,7 +26,7 @@ module ThemeCheck
       assert_offenses("", offenses)
     end
 
-    def test_regex_doesnt_hang_on_self_closing_tag
+    def test_doesnt_hang_on_self_closing_tag
       offenses = analyze_theme(
         ImgWidthAndHeight.new,
         "templates/index.liquid" => <<~END,

--- a/test/checks/parser_blocking_javascript_test.rb
+++ b/test/checks/parser_blocking_javascript_test.rb
@@ -58,18 +58,6 @@ class ParserBlockingJavaScriptTest < Minitest::Test
     END
   end
 
-  def test_script_tag_filter
-    offenses = analyze_theme(
-      ThemeCheck::ParserBlockingJavaScript.new,
-      "templates/index.liquid" => <<~END,
-        {{ 'foo.js' | asset_url | script_tag }}
-      END
-    )
-    assert_offenses(<<~END, offenses)
-      The script_tag filter is parser-blocking. Use a script tag with the async or defer attribute for better performance at templates/index.liquid:1
-    END
-  end
-
   def test_parser_blocking_script_over_multiple_lines
     offenses = analyze_theme(
       ThemeCheck::ParserBlockingJavaScript.new,

--- a/test/checks/parser_blocking_script_tag_test.rb
+++ b/test/checks/parser_blocking_script_tag_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class ParserBlockingScriptTagTest < Minitest::Test
+  def test_script_tag_filter
+    offenses = analyze_theme(
+      ThemeCheck::ParserBlockingScriptTag.new,
+      "templates/index.liquid" => <<~END,
+        {{ 'foo.js' | asset_url | script_tag }}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      The script_tag filter is parser-blocking. Use a script tag with the async or defer attribute for better performance at templates/index.liquid:1
+    END
+  end
+end

--- a/test/html_visitor_test.rb
+++ b/test/html_visitor_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class HtmlVisitorTest < Minitest::Test
+  def setup
+    @tracer = TracerCheck.new
+    @visitor = ThemeCheck::HtmlVisitor.new(ThemeCheck::Checks.new([@tracer]))
+  end
+
+  def test_elements_with_variables
+    template = parse_liquid(<<~END)
+      <a href="/about">About</a>
+      <img src="a.jpg" width="{{ image.width }}" height="{{ image.height }}">
+    END
+    @visitor.visit_template(template)
+    assert_equal([
+      :on_document,
+      :on_a,
+      :on_text, "About",
+      :after_a,
+      :on_text, "\n",
+      :on_img,
+      :after_img,
+      :on_text, "\n",
+      :after_document
+    ], @tracer.calls)
+  end
+
+  def test_elements_with_liquid_tags
+    template = parse_liquid(<<~END)
+      {% capture x %}
+        <a href="/about">About</a>
+      {% endcapture %}
+    END
+    @visitor.visit_template(template)
+    assert_equal([
+      :on_document,
+      :on_text, "{% capture x %}\n  ",
+      :on_a,
+      :on_text, "About",
+      :after_a,
+      :on_text, "\n{% endcapture %}\n",
+      :after_document
+    ], @tracer.calls)
+  end
+end


### PR DESCRIPTION
Ends up we can parse `.liquid` files that contain HTML with Nokogumbo (Ruby wrapper around [Gumbo](https://github.com/google/gumbo-parser), we're already using it for validating translations). It will just threat the Liquid bits as text nodes.

With the resulting AST we get from Gumbo, we can now make HtmlCheck look a lot like the LiquidCheck that use the Liquid AST:

```ruby
class ParserBlockingJavaScript < HtmlCheck
  # ...
  def on_script(node)
    return unless node.attributes["src"]
    return if node.attributes["defer"] || node.attributes["async"] || node.attributes["type"]&.value == "module"

    add_offense("Missing async or defer attribute on script tag", node: node)
  end
end
```

This removes the need to rely on regexp to parse the HTML. It makes the checks simpler, and more robust.

Fixes #298 

Still need to port a few remaining regexp checks to this.

I split the `ParserBlockingJavaScript` into two checks, one HtmlCheck, and one LiquidCheck for `script_tag`. I think that's the approach we should take when we need to check both the Liquid AST & HTML AST.