### PR TITLE
Convert `RemoteAsset` into an `HtmlCheck`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -130,6 +130,10 @@ RemoteAsset:
   enabled: true
   ignore: []
 
+AssetUrlFilters:
+  enabled: true
+  ignore: []
+
 ContentForHeaderModification:
   enabled: true
   ignore: []

--- a/docs/checks/asset_url_filters.md
+++ b/docs/checks/asset_url_filters.md
@@ -1,0 +1,56 @@
+# Ensure `asset_url` filters are used when serving assets (`AssetUrlFilters`)
+
+See the [`RemoteAsset` check documentation][remote_asset] for a detailed explanation on why remote assets are discouraged.
+
+## Check Details
+
+This check is aimed at eliminating unnecessary HTTP connections.
+
+:-1: Examples of **incorrect** code for this check:
+
+```liquid
+<!-- Using multiple CDNs -->
+{{ "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" | stylesheet_tag }}
+
+<!-- Missing img_url filter -->
+{{ url | img_tag }}
+```
+
+:+1: Examples of **correct** code for this check:
+
+```liquid
+{{ 'bootstrap.min.css' | asset_url | stylesheet_tag }}
+
+<!-- Images -->
+{{ url | img_url | img_tag }}
+```
+
+Use the [`assets_url`](asset_url) or [`img_url`](img_url) filter to load the files in your theme's `assets/` folder from the Shopify CDN.
+
+## Check Options
+
+The default configuration for this check is the following:
+
+```yaml
+AssetUrlFilters:
+  enabled: true
+```
+
+## When Not To Use It
+
+When the remote content is highly dynamic.
+
+## Version
+
+This check has been introduced in Theme Check THEME_CHECK_VERSION.
+
+## Resources
+
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[codesource]: /lib/theme_check/checks/remote_asset_filters.rb
+[docsource]: /docs/checks/remote_asset_filters.md
+[remote_asset]: /docs/checks/remote_asset.md
+[asset_url]: https://shopify.dev/docs/themes/liquid/reference/filters/url-filters#assert_url
+[img_url]: https://shopify.dev/docs/themes/liquid/reference/filters/url-filters#img_url

--- a/lib/theme_check/checks/asset_url_filters.rb
+++ b/lib/theme_check/checks/asset_url_filters.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+module ThemeCheck
+  class AssetUrlFilters < LiquidCheck
+    severity :suggestion
+    categories :liquid, :performance
+    doc docs_url(__FILE__)
+
+    HTML_FILTERS = [
+      'stylesheet_tag',
+      'script_tag',
+      'img_tag',
+    ]
+    ASSET_URL_FILTERS = [
+      'asset_url',
+      'asset_img_url',
+      'file_img_url',
+      'file_url',
+      'global_asset_url',
+      'img_url',
+      'payment_type_img_url',
+      'shopify_asset_url',
+    ]
+
+    def on_variable(node)
+      record_variable_offense(node)
+    end
+
+    private
+
+    def record_variable_offense(variable_node)
+      # We flag HTML tags with URLs not hosted by Shopify
+      return if !html_resource_drop?(variable_node) || variable_hosted_by_shopify?(variable_node)
+      add_offense("Use one of the asset_url filters to serve assets", node: variable_node)
+    end
+
+    def html_resource_drop?(variable_node)
+      variable_node.value.filters
+        .any? { |(filter_name, *_filter_args)| HTML_FILTERS.include?(filter_name) }
+    end
+
+    def variable_hosted_by_shopify?(variable_node)
+      variable_node.value.filters
+        .any? { |(filter_name, *_filter_args)| ASSET_URL_FILTERS.include?(filter_name) }
+    end
+  end
+end

--- a/lib/theme_check/checks/remote_asset.rb
+++ b/lib/theme_check/checks/remote_asset.rb
@@ -1,99 +1,41 @@
 # frozen_string_literal: true
 module ThemeCheck
-  class RemoteAsset < LiquidCheck
-    include RegexHelpers
+  class RemoteAsset < HtmlCheck
     severity :suggestion
-    categories :liquid, :performance
+    categories :html, :performance
     doc docs_url(__FILE__)
 
-    OFFENSE_MESSAGE = "Asset should be served by the Shopify CDN for better performance."
-
-    HTML_FILTERS = [
-      'stylesheet_tag',
-      'script_tag',
-      'img_tag',
-    ]
-    ASSET_URL_FILTERS = [
-      'asset_url',
-      'asset_img_url',
-      'file_img_url',
-      'file_url',
-      'global_asset_url',
-      'img_url',
-      'payment_type_img_url',
-      'shopify_asset_url',
-    ]
-
-    RESOURCE_TAG = %r{<(?<tag_name>img|script|link|source)#{HTML_ATTRIBUTES}/?>}oim
-    RESOURCE_URL = /\s(?:src|href)=(?<resource_url>#{QUOTED_LIQUID_ATTRIBUTE})/oim
-    ASSET_URL_FILTER = /[\|\s]*(#{ASSET_URL_FILTERS.join('|')})/omi
+    TAGS = %w[img script link source]
     PROTOCOL = %r{(https?:)?//}
     ABSOLUTE_PATH = %r{\A/[^/]}im
     RELATIVE_PATH = %r{\A(?!#{PROTOCOL})[^/\{]}oim
-    REL = /\srel=(?<rel>#{QUOTED_LIQUID_ATTRIBUTE})/oim
 
-    def on_variable(node)
-      record_variable_offense(node)
-    end
+    def on_element(node)
+      return unless TAGS.include?(node.name)
 
-    def on_document(node)
-      source = node.template.source
-      record_html_offenses(node, source)
+      resource_url = node.attributes["src"]&.value || node.attributes["href"]&.value
+      return if resource_url.nil? || resource_url.empty?
+
+      # Ignore if URL is Liquid, taken care of by AssetUrlFilters check
+      return if resource_url =~ ABSOLUTE_PATH
+      return if resource_url =~ RELATIVE_PATH
+      return if url_hosted_by_shopify?(resource_url)
+
+      # Ignore non-stylesheet rel tags
+      rel = node.attributes["rel"]
+      return if rel && rel.value != "stylesheet"
+
+      add_offense(
+        "Asset should be served by the Shopify CDN for better performance.",
+        node: node,
+      )
     end
 
     private
 
-    def record_variable_offense(variable_node)
-      # We flag HTML tags with URLs not hosted by Shopify
-      return if !html_resource_drop?(variable_node) || variable_hosted_by_shopify?(variable_node)
-      add_offense(OFFENSE_MESSAGE, node: variable_node)
-    end
-
-    def html_resource_drop?(variable_node)
-      variable_node.value.filters
-        .any? { |(filter_name, *_filter_args)| HTML_FILTERS.include?(filter_name) }
-    end
-
-    def variable_hosted_by_shopify?(variable_node)
-      variable_node.value.filters
-        .any? { |(filter_name, *_filter_args)| ASSET_URL_FILTERS.include?(filter_name) }
-    end
-
-    # This part is slightly more complicated because we don't have an
-    # HTML AST. We have to resort to looking at the HTML with regexes
-    # to figure out if we have a resource (stylesheet, script, or media)
-    # that points to a remote domain.
-    def record_html_offenses(node, source)
-      matches(source, RESOURCE_TAG).each do |match|
-        tag = match[0]
-
-        # We don't flag stuff without URLs
-        next unless tag =~ RESOURCE_URL
-        resource_match = Regexp.last_match
-        resource_url = resource_match[:resource_url].gsub(START_OR_END_QUOTE, '')
-
-        next if non_stylesheet_link?(tag)
-        next if url_hosted_by_shopify?(resource_url)
-        next if resource_url =~ ABSOLUTE_PATH
-        next if resource_url =~ RELATIVE_PATH
-        next if resource_url.empty?
-
-        start = match.begin(0) + resource_match.begin(:resource_url)
-        add_offense(
-          OFFENSE_MESSAGE,
-          node: node,
-          markup: resource_url,
-          line_number: source[0...start].count("\n") + 1,
-        )
-      end
-    end
-
-    def non_stylesheet_link?(tag)
-      tag =~ REL && !(Regexp.last_match[:rel] =~ /\A['"]stylesheet['"]\Z/)
-    end
-
     def url_hosted_by_shopify?(url)
-      url =~ /\A#{VARIABLE}\Z/oim && url =~ ASSET_URL_FILTER
+      url.start_with?(Liquid::VariableStart) &&
+        AssetUrlFilters::ASSET_URL_FILTERS.any? { |filter| url.include?(filter) }
     end
   end
 end

--- a/lib/theme_check/html_node.rb
+++ b/lib/theme_check/html_node.rb
@@ -17,6 +17,10 @@ module ThemeCheck
       @value.name == "text"
     end
 
+    def element?
+      @value.element?
+    end
+
     def children
       @value.children.map { |child| HtmlNode.new(child, template) }
     end

--- a/lib/theme_check/html_visitor.rb
+++ b/lib/theme_check/html_visitor.rb
@@ -22,10 +22,12 @@ module ThemeCheck
     end
 
     def visit(node)
+      call_checks(:on_element, node) if node.element?
       call_checks(:"on_#{node.name}", node)
       node.children.each { |child| visit(child) }
       unless node.literal?
         call_checks(:"after_#{node.name}", node)
+        call_checks(:after_element, node) if node.element?
       end
     end
 

--- a/lib/theme_check/liquid_check.rb
+++ b/lib/theme_check/liquid_check.rb
@@ -6,6 +6,7 @@ module ThemeCheck
     extend ChecksTracking
     include ParsingHelpers
 
+    # TODO: remove this once all regex checks are migrate to HtmlCheck# TODO: remove this once all regex checks are migrate to HtmlCheck
     TAG = /#{Liquid::TagStart}.*?#{Liquid::TagEnd}/om
     VARIABLE = /#{Liquid::VariableStart}.*?#{Liquid::VariableEnd}/om
     START_OR_END_QUOTE = /(^['"])|(['"]$)/

--- a/test/checks/asset_url_filters_test.rb
+++ b/test/checks/asset_url_filters_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module ThemeCheck
+  class AssetUrlFiltersTest < Minitest::Test
+    def test_no_offense_for_good_behaviour
+      offenses = analyze_theme(
+        AssetUrlFilters.new,
+        "templates/index.liquid" => <<~END,
+          <!-- scripts -->
+          <script src="{{ 'theme.js' | asset_url }}" defer></script>
+
+          <!-- styles -->
+          {{ 'theme.css' | asset_url | stylesheet_tag }}
+          <link href="{{ 'theme.css' | asset_url }}" rel="stylesheet">
+
+          <!-- images -->
+          <img alt="logo" src="{{ 'heart.png' | asset_url }}" width="100" height="100">
+          <img alt="logo" src="{{ 'heart.png' | asset_url }}" width="100" height="100"/>
+          <source src="{{ 'heart.png' | asset_url }}">
+
+          <!-- all kinds of html_filters (while using asset_url filters) -->
+          {{ url | asset_url | img_tag }}
+          {{ url | asset_img_url | script_tag }}
+          {{ url | file_img_url | img_tag }}
+          {{ url | file_url | script_tag }}
+          {{ url | global_asset_url | script_tag }}
+          {{ url | payment_type_img_url | img_tag }}
+          {{ url | shopify_asset_url | img_tag }}
+        END
+      )
+      assert_offenses("", offenses)
+    end
+
+    # Note: this highlights how we might have a false positive for assign that uses the asset_url.
+    # This doesn't feel like a common practice though.
+    def test_flag_use_of_html_filter_without_asset_url_filter
+      offenses = analyze_theme(
+        AssetUrlFilters.new,
+        "templates/index.liquid" => <<~END,
+          {{ url | img_tag }}
+          {{ url | script_tag }}
+          {{ url | stylesheet_tag }}
+        END
+      )
+      assert_offenses(<<~END, offenses)
+        Use one of the asset_url filters to serve assets at templates/index.liquid:1
+        Use one of the asset_url filters to serve assets at templates/index.liquid:2
+        Use one of the asset_url filters to serve assets at templates/index.liquid:3
+      END
+    end
+
+    def test_flag_use_of_remote_stylesheet
+      offenses = analyze_theme(
+        AssetUrlFilters.new,
+        "templates/index.liquid" => <<~END,
+          {{ "https://example.com/tailwind.css" | stylesheet_tag }}
+        END
+      )
+      assert_offenses(<<~END, offenses)
+        Use one of the asset_url filters to serve assets at templates/index.liquid:1
+      END
+    end
+
+    def test_flag_use_of_image_drops_without_img_url_filter
+      offenses = analyze_theme(
+        AssetUrlFilters.new,
+        "templates/index.liquid" => <<~END,
+          {{ image | img_tag }}
+          {{ image.src | img_tag }}
+        END
+      )
+      assert_offenses(<<~END, offenses)
+        Use one of the asset_url filters to serve assets at templates/index.liquid:1
+        Use one of the asset_url filters to serve assets at templates/index.liquid:2
+      END
+    end
+  end
+end

--- a/test/checks/remote_asset_test.rb
+++ b/test/checks/remote_asset_test.rb
@@ -27,15 +27,6 @@ module ThemeCheck
           <source src="{{ image.src | img_url }}">
           <source src="{{ image | img_url }}">
 
-          <!-- all kinds of html_filters (while using asset_url filters) -->
-          {{ url | asset_url | img_tag }}
-          {{ url | asset_img_url | script_tag }}
-          {{ url | file_img_url | img_tag }}
-          {{ url | file_url | script_tag }}
-          {{ url | global_asset_url | script_tag }}
-          {{ url | payment_type_img_url | img_tag }}
-          {{ url | shopify_asset_url | img_tag }}
-
           <!-- weird edge cases from the wild -->
           <img alt="logo" src="" data-src="{{ url | asset_url | img_tag }}" width="100" height="100" />
         END
@@ -71,31 +62,11 @@ module ThemeCheck
         "templates/index.liquid" => <<~END,
           <link href="https://example.com/bootstrap.css" rel="stylesheet">
           <link href="{{ "https://example.com/bootstrap.css" | replace: 'bootstrap', 'tailwind' }}" rel="stylesheet">
-          {{ "https://example.com/tailwind.css" | stylesheet_tag }}
         END
       )
       assert_offenses(<<~END, offenses)
         Asset should be served by the Shopify CDN for better performance. at templates/index.liquid:1
         Asset should be served by the Shopify CDN for better performance. at templates/index.liquid:2
-        Asset should be served by the Shopify CDN for better performance. at templates/index.liquid:3
-      END
-    end
-
-    # Note: this highlights how we might have a false positive for assign that uses the asset_url.
-    # This doesn't feel like a common practice though.
-    def test_flag_use_of_html_filter_without_asset_url_filter
-      offenses = analyze_theme(
-        RemoteAsset.new,
-        "templates/index.liquid" => <<~END,
-          {{ url | img_tag }}
-          {{ url | script_tag }}
-          {{ url | stylesheet_tag }}
-        END
-      )
-      assert_offenses(<<~END, offenses)
-        Asset should be served by the Shopify CDN for better performance. at templates/index.liquid:1
-        Asset should be served by the Shopify CDN for better performance. at templates/index.liquid:2
-        Asset should be served by the Shopify CDN for better performance. at templates/index.liquid:3
       END
     end
 
@@ -103,8 +74,6 @@ module ThemeCheck
       offenses = analyze_theme(
         RemoteAsset.new,
         "templates/index.liquid" => <<~END,
-          {{ image | img_tag }}
-          {{ image.src | img_tag }}
           <img src="{{ image }}">
           <img src="{{ image.src }}">
         END
@@ -112,8 +81,6 @@ module ThemeCheck
       assert_offenses(<<~END, offenses)
         Asset should be served by the Shopify CDN for better performance. at templates/index.liquid:1
         Asset should be served by the Shopify CDN for better performance. at templates/index.liquid:2
-        Asset should be served by the Shopify CDN for better performance. at templates/index.liquid:3
-        Asset should be served by the Shopify CDN for better performance. at templates/index.liquid:4
       END
     end
   end

--- a/test/html_visitor_test.rb
+++ b/test/html_visitor_test.rb
@@ -15,12 +15,16 @@ class HtmlVisitorTest < Minitest::Test
     @visitor.visit_template(template)
     assert_equal([
       :on_document,
+      :on_element,
       :on_a,
       :on_text, "About",
       :after_a,
+      :after_element,
       :on_text, "\n",
+      :on_element,
       :on_img,
       :after_img,
+      :after_element,
       :on_text, "\n",
       :after_document
     ], @tracer.calls)
@@ -36,9 +40,11 @@ class HtmlVisitorTest < Minitest::Test
     assert_equal([
       :on_document,
       :on_text, "{% capture x %}\n  ",
+      :on_element,
       :on_a,
       :on_text, "About",
       :after_a,
+      :after_element,
       :on_text, "\n{% endcapture %}\n",
       :after_document
     ], @tracer.calls)


### PR DESCRIPTION
And move Liquid specifics to a new `AssetUrlFilters` check.

Fixes #305

### Editorial note on `HtmlCheck` & `LiquidCheck`

I see now that it would be better to combine both type of checks into one, so you could check Liquid & HTML at the same time & get the context from both. But I don't see how we could do this, we'd need to merge both ASTs... I don't see how this could be done.

So we're kind of stuck having to do a bit of Liquid parsing inside `HtmlCheck` sometimes.