### PR TITLE
Convert `AssetSizeJavaScript` to `HtmlCheck`

### DIFF
--- a/lib/theme_check/html_check.rb
+++ b/lib/theme_check/html_check.rb
@@ -3,5 +3,7 @@
 module ThemeCheck
   class HtmlCheck < Check
     extend ChecksTracking
+    VARIABLE = /#{Liquid::VariableStart}.*?#{Liquid::VariableEnd}/om
+    START_OR_END_QUOTE = /(^['"])|(['"]$)/
   end
 end


### PR DESCRIPTION
### What does this do?
Convert `AssetSizeJavaScript` from `LiquidCheck` to `HtmlCheck`.
### How does it do it?
Makes the `AssetSizeJavaScript` class a subclass of HtmlCheck. Removes the `scripts()` processing method and any regex constants.
### Why did you pick this approach over other options?
Removes the need to rely on regexp to parse the HTML. It makes the checks simpler, and more robust.