### PR TITLE
Add `HtmlParsingError` check for reporting errors during HTML parsing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -75,7 +75,7 @@ task :new_check, [:name] do |_t, args|
     code_source: code_source,
     doc_source: doc_source,
   )
-  sh "bundle exec ruby -Itest test/checks/my_new_check_test.rb"
+  sh "bundle exec ruby -Itest #{test_source}"
 end
 
 def erb(file, to, **args)

--- a/config/default.yml
+++ b/config/default.yml
@@ -141,3 +141,7 @@ ContentForHeaderModification:
 ImgLazyLoading:
   enabled: true
   ignore: []
+
+HtmlParsingError:
+  enabled: true
+  ignore: []

--- a/docs/checks/html_parsing_error.md
+++ b/docs/checks/html_parsing_error.md
@@ -1,0 +1,50 @@
+# Report HTML parsing errors (`HtmlParsingError`)
+
+Report errors preventing the HTML from being parsed and analyzed by Theme Check.
+
+## Check Details
+
+This check is aimed at reporting HTML errors that prevent a file from being analyzed.
+
+The HTML parser limits the number of attributes per element to 400, and the maximum depth of the DOM tree to 400 levels. If any one of those limits is reached, parsing stops, and all HTML offenses on this file are ignored.
+
+:-1: Examples of **incorrect** code for this check:
+
+```liquid
+<img src="muffin.jpeg"
+     data-attrbute-1=""
+     data-attrbute-2=""
+     ... up to
+     data-attrbute-400="">
+```
+
+:+1: Examples of **correct** code for this check:
+
+```liquid
+<img src="muffin.jpeg">
+```
+
+## Check Options
+
+The default configuration for this check is the following:
+
+```yaml
+HtmlParsingError:
+  enabled: true
+```
+
+## When Not To Use It
+
+If you don't care about HTML offenses.
+
+## Version
+
+This check has been introduced in Theme Check THEME_CHECK_VERSION.
+
+## Resources
+
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[codesource]: /lib/theme_check/checks/html_parsing_error.rb
+[docsource]: /docs/checks/html_parsing_error.md

--- a/lib/theme_check/checks/html_parsing_error.rb
+++ b/lib/theme_check/checks/html_parsing_error.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module ThemeCheck
+  class HtmlParsingError < HtmlCheck
+    severity :error
+    category :html
+    doc docs_url(__FILE__)
+
+    def on_parse_error(exception, template)
+      add_offense("HTML in this template can not be parsed: #{exception.message}", template: template)
+    end
+  end
+end

--- a/lib/theme_check/html_visitor.rb
+++ b/lib/theme_check/html_visitor.rb
@@ -13,12 +13,14 @@ module ThemeCheck
     def visit_template(template)
       doc = parse(template)
       visit(HtmlNode.new(doc, template))
+    rescue ArgumentError => e
+      call_checks(:on_parse_error, e, template)
     end
 
     private
 
     def parse(template)
-      Nokogiri::HTML5.fragment(template.source)
+      Nokogiri::HTML5.fragment(template.source, max_tree_depth: 400, max_attributes: 400)
     end
 
     def visit(node)

--- a/test/checks/html_parsing_error_test.rb
+++ b/test/checks/html_parsing_error_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class HtmlParsingErrorTest < Minitest::Test
+  def test_valid
+    offenses = analyze_theme(
+      ThemeCheck::HtmlParsingError.new,
+      "templates/index.liquid" => <<~END,
+        <img src="muffin.jpeg" atl="Muffin">
+      END
+    )
+    assert_offenses("", offenses)
+  end
+
+  def test_reports_to_many_attributes
+    offenses = analyze_theme(
+      ThemeCheck::HtmlParsingError.new,
+      "templates/index.liquid" => <<~END,
+        <img src="muffin.jpeg" #{(1..400).map { |i| "attribute#{i}" }.join(" ")}>
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      HTML in this template can not be parsed: Attributes per element limit exceeded at templates/index.liquid
+    END
+  end
+end


### PR DESCRIPTION
### Problem

The HTML parser we're using (Gumbo) [limits the number of attributes per element to 400, and the maximum depth of the DOM tree to 400 levels](https://github.com/rubys/nokogumbo#attribute-limit-per-element).

This throws an exception that crashes Theme Check, see #317.

### Solution

We could bump to limits, or remove the limits, but that seems risky to me to parse without limits. So instead I chose the approach of reporting the errors in a new check, similar to `SyntaxError` for reporting Liquid parsing errors.

If any one of the limit is reached, parsing stops, and all HTML offenses on this file are ignored. This is mentioned in the check doc.

Fixes #317