### PR TITLE
Convert `AssetSizeCSS` to `HtmlCheck`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -109,16 +109,22 @@ ParserBlockingJavaScript:
 
 ParserBlockingScriptTag:
   enabled: true
+  ignore: []
 
 AssetSizeJavaScript:
   enabled: false
-  ignore: []
   threshold_in_bytes: 10_000
+  ignore: []
 
 AssetSizeCSS:
   enabled: false
-  ignore: []
   threshold_in_bytes: 100_000
+  ignore: []
+
+AssetSizeCSSStylesheetTag:
+  enabled: false
+  threshold_in_bytes: 100_000
+  ignore: []
 
 ImgWidthAndHeight:
   enabled: true

--- a/docs/checks/asset_size_css_stylesheet_tag.md
+++ b/docs/checks/asset_size_css_stylesheet_tag.md
@@ -1,0 +1,50 @@
+# Check Title (`AssetSizeCSSStylesheetTag`)
+
+The `stylesheet_tag` filter generates a link tag that points to a given stylesheet. This rule exists to prevent large CSS bundles (for speed).
+
+## Check Details
+
+This rule disallows the use of too much CSS in themes, as configured by `threshold_in_bytes`.
+
+:-1: Examples of **incorrect** code for this check:
+```liquid
+<!-- Here, assets/theme.css is **greater** than `threshold_in_bytes` compressed. -->
+{{ 'theme.css' | asset_url | stylesheet_tag }}
+```
+
+:+1: Example of **correct** code for this check:
+```liquid
+<!-- Here, assets/theme.css is **less** than `threshold_in_bytes` compressed. -->
+{{ 'theme.css' | asset_url | stylesheet_tag }}
+```
+
+## Check Options
+
+The default configuration for this check is the following:
+
+```yaml
+AssetSizeCSSStylesheetTag:
+  enabled: false
+  threshold_in_bytes: 100_000
+```
+
+### `threshold_in_bytes`
+
+The `threshold_in_bytes` option (default: `100_000`) determines the maximum allowed compressed size in bytes that a single CSS file can take.
+
+## When Not To Use It
+
+This rule is safe to disable.
+
+## Version
+
+This check has been introduced in Theme Check THEME_CHECK_VERSION
+
+## Resources
+
+- [The Performance Inequality Gap](https://infrequently.org/2021/03/the-performance-inequality-gap/)
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[codesource]: /lib/theme_check/checks/asset_size_css_stylesheet_tag.rb
+[docsource]: /docs/checks/asset_size_css_stylesheet_tag.md

--- a/lib/theme_check/checks/asset_size_css.rb
+++ b/lib/theme_check/checks/asset_size_css.rb
@@ -1,29 +1,10 @@
 # frozen_string_literal: true
 module ThemeCheck
-  class AssetSizeCSS < LiquidCheck
+  class AssetSizeCSS < HtmlCheck
     include RegexHelpers
     severity :error
-    category :performance
+    category :html, :performance
     doc docs_url(__FILE__)
-
-    Link = Struct.new(:href, :index)
-
-    LINK_TAG_HREF = %r{
-      <link
-        (?=[^>]+?rel=['"]?stylesheet['"]?)    # Make sure rel=stylesheet is in the link with lookahead
-        [^>]+                                 # any non closing tag character
-        href=                                 # href attribute start
-        (?<href>#{QUOTED_LIQUID_ATTRIBUTE})   # href attribute value (may contain liquid)
-        [^>]*                                 # any non closing character till the end
-      >
-    }omix
-    STYLESHEET_TAG = %r{
-      #{Liquid::VariableStart}          # VariableStart
-      (?:(?!#{Liquid::VariableEnd}).)*? # anything that isn't followed by a VariableEnd
-      \|\s*asset_url\s*                 # | asset_url
-      \|\s*stylesheet_tag\s*            # | stylesheet_tag
-      #{Liquid::VariableEnd}            # VariableEnd
-    }omix
 
     attr_reader :threshold_in_bytes
 
@@ -31,59 +12,15 @@ module ThemeCheck
       @threshold_in_bytes = threshold_in_bytes
     end
 
-    def on_document(node)
-      @node = node
-      @source = node.template.source
-      record_offenses
-    end
-
-    def record_offenses
-      stylesheets(@source).each do |stylesheet|
-        file_size = href_to_file_size(stylesheet.href)
-        next if file_size.nil?
-        next if file_size <= threshold_in_bytes
-        add_offense(
-          "CSS on every page load exceeds compressed size threshold (#{threshold_in_bytes} Bytes).",
-          node: @node,
-          markup: stylesheet.href,
-          line_number: @source[0...stylesheet.index].count("\n") + 1
-        )
-      end
-    end
-
-    def stylesheets(source)
-      stylesheet_links = matches(source, LINK_TAG_HREF)
-        .map do |m|
-          Link.new(
-            m[:href].gsub(START_OR_END_QUOTE, ""),
-            m.begin(:href),
-          )
-        end
-
-      stylesheet_tags = matches(source, STYLESHEET_TAG)
-        .map do |m|
-          Link.new(
-            m[0],
-            m.begin(0),
-          )
-        end
-
-      stylesheet_links + stylesheet_tags
-    end
-
-    def href_to_file_size(href)
-      # asset_url (+ optional stylesheet_tag) variables
-      if href =~ /^#{VARIABLE}$/o && href =~ /asset_url/ && href =~ Liquid::QuotedString
-        asset_id = Regexp.last_match(0).gsub(START_OR_END_QUOTE, "")
-        asset = @theme.assets.find { |a| a.name.end_with?("/" + asset_id) }
-        return if asset.nil?
-        asset.gzipped_size
-
-      # remote URLs
-      elsif href =~ %r{^(https?:)?//}
-        asset = RemoteAssetFile.from_src(href)
-        asset.gzipped_size
-      end
+    def on_link(node)
+      return if node.attributes['rel']&.value != "stylesheet"
+      file_size = href_to_file_size(node.attributes['href']&.value)
+      return if file_size.nil?
+      return if file_size <= threshold_in_bytes
+      add_offense(
+        "CSS on every page load exceeding compressed size threshold (#{threshold_in_bytes} Bytes).",
+        node: node
+      )
     end
   end
 end

--- a/lib/theme_check/checks/asset_size_css_stylesheet_tag.rb
+++ b/lib/theme_check/checks/asset_size_css_stylesheet_tag.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module ThemeCheck
+  class AssetSizeCSSStylesheetTag < LiquidCheck
+    include RegexHelpers
+    severity :error
+    category :liquid, :performance
+    doc docs_url(__FILE__)
+
+    def initialize(threshold_in_bytes: 100_000)
+      @threshold_in_bytes = threshold_in_bytes
+    end
+
+    def on_variable(node)
+      used_filters = node.value.filters.map { |name, *_rest| name }
+      return unless used_filters.include?("stylesheet_tag")
+      file_size = href_to_file_size('{{' + node.markup + '}}')
+      return if file_size <= @threshold_in_bytes
+      add_offense(
+        "CSS on every page load exceeding compressed size threshold (#{@threshold_in_bytes} Bytes).",
+        node: node
+      )
+    end
+  end
+end

--- a/lib/theme_check/checks/asset_size_javascript.rb
+++ b/lib/theme_check/checks/asset_size_javascript.rb
@@ -4,6 +4,7 @@ module ThemeCheck
   # Encourages the use of the Import on Interaction pattern [1].
   # [1]: https://addyosmani.com/blog/import-on-interaction/
   class AssetSizeJavaScript < HtmlCheck
+    include RegexHelpers
     severity :error
     category :html, :performance
     doc docs_url(__FILE__)

--- a/lib/theme_check/liquid_check.rb
+++ b/lib/theme_check/liquid_check.rb
@@ -5,17 +5,5 @@ module ThemeCheck
   class LiquidCheck < Check
     extend ChecksTracking
     include ParsingHelpers
-
-    # TODO: remove this once all regex checks are migrate to HtmlCheck# TODO: remove this once all regex checks are migrate to HtmlCheck
-    TAG = /#{Liquid::TagStart}.*?#{Liquid::TagEnd}/om
-    VARIABLE = /#{Liquid::VariableStart}.*?#{Liquid::VariableEnd}/om
-    START_OR_END_QUOTE = /(^['"])|(['"]$)/
-    QUOTED_LIQUID_ATTRIBUTE = %r{
-      '(?:#{TAG}|#{VARIABLE}|[^'])*'| # any combination of tag/variable or non straight quote inside straight quotes
-      "(?:#{TAG}|#{VARIABLE}|[^"])*"  # any combination of tag/variable or non double quotes inside double quotes
-    }omix
-    ATTR = /[a-z0-9-]+/i
-    HTML_ATTRIBUTE = /#{ATTR}(?:=#{QUOTED_LIQUID_ATTRIBUTE})?/omix
-    HTML_ATTRIBUTES = /(?:#{HTML_ATTRIBUTE}|\s)*/omix
   end
 end

--- a/lib/theme_check/regex_helpers.rb
+++ b/lib/theme_check/regex_helpers.rb
@@ -2,6 +2,8 @@
 
 module ThemeCheck
   module RegexHelpers
+    VARIABLE = /#{Liquid::VariableStart}.*?#{Liquid::VariableEnd}/om
+    START_OR_END_QUOTE = /(^['"])|(['"]$)/
     def matches(s, re)
       start_at = 0
       matches = []
@@ -10,6 +12,21 @@ module ThemeCheck
         start_at = m.end(0)
       end
       matches
+    end
+
+    def href_to_file_size(href)
+      # asset_url (+ optional stylesheet_tag) variables
+      if href =~ /^#{VARIABLE}$/o && href =~ /asset_url/ && href =~ Liquid::QuotedString
+        asset_id = Regexp.last_match(0).gsub(START_OR_END_QUOTE, "")
+        asset = @theme.assets.find { |a| a.name.end_with?("/" + asset_id) }
+        return if asset.nil?
+        asset.gzipped_size
+
+      # remote URLs
+      elsif href =~ %r{^(https?:)?//}
+        asset = RemoteAssetFile.from_src(href)
+        asset.gzipped_size
+      end
     end
   end
 end

--- a/test/checks/asset_size_css_stylesheet_tag_test.rb
+++ b/test/checks/asset_size_css_stylesheet_tag_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module ThemeCheck
+  class AssetSizeCSSStylesheetTagTest < Minitest::Test
+    def test_css_bundles_smaller_than_threshold
+      offenses = analyze_theme(
+        AssetSizeCSSStylesheetTag.new(threshold_in_bytes: 10000000),
+        {
+          "assets/theme.css" => <<~JS,
+            console.log('hello world');
+          JS
+          "templates/index.liquid" => <<~END,
+            <html>
+              <head>
+                {{ 'theme.css' | asset_url | stylesheet_tag }}
+              </head>
+            </html>
+          END
+        }
+      )
+      assert_offenses("", offenses)
+    end
+
+    def test_css_bundles_bigger_than_threshold
+      offenses = analyze_theme(
+        AssetSizeCSSStylesheetTag.new(threshold_in_bytes: 2),
+        "assets/theme.css" => <<~JS,
+          console.log('hello world');
+        JS
+        "templates/index.liquid" => <<~END,
+          <html>
+            <head>
+              {{ 'theme.css' | asset_url | stylesheet_tag }}
+            </head>
+          </html>
+        END
+      )
+      assert_offenses(<<~END, offenses)
+        CSS on every page load exceeding compressed size threshold (2 Bytes). at templates/index.liquid:3
+      END
+    end
+
+    def test_no_stylesheet
+      offenses = analyze_theme(
+        AssetSizeCSSStylesheetTag.new(threshold_in_bytes: 100000),
+        "templates/index.liquid" => <<~END,
+          <html>
+            <head>
+            </head>
+          </html>
+        END
+      )
+      assert_offenses("", offenses)
+    end
+  end
+end

--- a/test/checks/asset_size_css_test.rb
+++ b/test/checks/asset_size_css_test.rb
@@ -3,87 +3,6 @@ require "test_helper"
 
 module ThemeCheck
   class AssetSizeCSSTest < Minitest::Test
-    def test_link_tag_regex
-      # using quotes
-      assert_href(<<~EXPECTED.strip, <<~SOURCE)
-        "{{ 'theme.css' | asset_url }}"
-      EXPECTED
-        <link href="{{ 'theme.css' | asset_url }}" rel="stylesheet">
-      SOURCE
-
-      # using straight quotes
-      assert_href(<<~EXPECTED.strip, <<~SOURCE)
-        '{{ 'theme.css' | asset_url }}'
-      EXPECTED
-        <link rel="stylesheet" href='{{ 'theme.css' | asset_url }}'>
-      SOURCE
-
-      # with follow up boolean attribute
-      assert_href(<<~EXPECTED.strip, <<~SOURCE)
-        "/theme.css"
-      EXPECTED
-        <link rel="stylesheet" href="/theme.css" disabled>
-      SOURCE
-
-      # with whitespace after boolean attribute
-      assert_href(<<~EXPECTED.strip, <<~SOURCE)
-        "theme.css"
-      EXPECTED
-        <link
-          rel="stylesheet"
-          href="theme.css"
-          media="all"
-          disabled
-        ></script>
-      SOURCE
-
-      # with whitespace inside variable
-      assert_href(<<~EXPECTED.strip, <<~SOURCE)
-        '{{
-            'theme.css' | asset_url
-          }}'
-      EXPECTED
-        <link
-          href='{{
-            'theme.css' | asset_url
-          }}'
-          rel="stylesheet"
-        ></script>
-      SOURCE
-    end
-
-    def assert_href(expected, source)
-      match = AssetSizeCSS::LINK_TAG_HREF.match(source)
-      assert(match, "Expected to extract #{expected} from #{source}")
-      assert_equal(expected, match[:href])
-    end
-
-    def test_stylesheet_extractor
-      check = AssetSizeCSS.new
-      stylesheets = check.stylesheets(<<~SOURCE)
-        <html>
-          <head>
-            <link href="{{ '1.css' | asset_url }}" rel="stylesheet" disabled>
-            <link href="{{ '2.css' | asset_url }}" rel="stylesheet" media="all">
-            <link href="3.css" rel="stylesheet">
-            <link rel="stylesheet" href="4.css">
-            {{ '5.css' | asset_url | stylesheet_tag }}
-            <link rel="preload" href="not-this.css">
-          </head>
-        </html>
-      SOURCE
-
-      expected = [
-        "{{ '1.css' | asset_url }}",
-        "{{ '2.css' | asset_url }}",
-        "3.css",
-        "4.css",
-        "{{ '5.css' | asset_url | stylesheet_tag }}",
-      ]
-
-      assert_equal(expected, stylesheets.map(&:href))
-    end
-
     def test_href_to_file_size
       theme = make_theme({
         "assets/theme.css" => "* { color: green !important; }",
@@ -143,14 +62,12 @@ module ThemeCheck
           <html>
             <head>
               <link href="{{ 'theme.css' | asset_url }}" rel="stylesheet">
-              {{ 'theme.css' | asset_url | stylesheet_tag }}
             </head>
           </html>
         END
       )
       assert_offenses(<<~END, offenses)
-        CSS on every page load exceeds compressed size threshold (2 Bytes). at templates/index.liquid:3
-        CSS on every page load exceeds compressed size threshold (2 Bytes). at templates/index.liquid:4
+        CSS on every page load exceeding compressed size threshold (2 Bytes). at templates/index.liquid:3
       END
     end
   end


### PR DESCRIPTION
### What does this do?
Convert `AssetSizeCSS` from `LiquidCheck` to `HtmlCheck`. Creates a new `LiquidCheck` for the stylesheet tag  called `AssetSizeCssStylesheetTag`.
### How does it do it?
Makes the `AssetSizeCSS` class a subclass of HtmlCheck. Removes the  processing method and any regex constants.
### Why did you pick this approach over other options?
Removes the need to rely on regexp to parse the HTML. It makes the checks simpler, and more robust.