### PR TITLE
`DeprecateLazysizes` and `DeprecateBgsizes`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -99,6 +99,14 @@ DeprecatedFilter:
   enabled: true
   ignore: []
 
+DeprecateLazysizes:
+  enabled: true
+  ignore: []
+
+DeprecateBgsizes:
+  enabled: true
+  ignore: []
+
 MissingEnableComment:
   enabled: true
   ignore: []

--- a/docs/checks/deprecate_bgsizes.md
+++ b/docs/checks/deprecate_bgsizes.md
@@ -1,0 +1,66 @@
+# Deprecate Bgsizes (`DeprecateBgsizes`)
+
+The lazySizes bgset extension allows you to define multiple background images with a width descriptor. The extension will then load the best image size for the current viewport and device (https://github.com/aFarkas/lazysizes/tree/gh-pages/plugins/bgset)
+
+
+## Check Details
+
+This check is aimed at discouraging the use of the lazySizes bgset plugin 
+
+:-1: Examples of **incorrect** code for this check:
+
+```liquid
+
+<!-- Reports use of "lazyload" class and "data-bgset" attribute -->
+
+<script src="ls.bgset.min.js"></script>
+<script src="lazysizes.min.js"></script>
+<div class="lazyload" data-bgset="image-200.jpg 200w, image-300.jpg 300w, image-400.jpg 400w" data-sizes="auto">
+</div>
+
+```
+
+:+1: Examples of **correct** code for this check:
+
+```liquid
+
+<!-- Uses the CSS image-set() attribute instead of "data-bgset" -->
+<!-- CSS Stylesheet -->
+.box {
+  background-image: -webkit-image-set(
+    url("small-balloons.jpg") 1x,
+    url("large-balloons.jpg") 2x);
+  background-image: image-set(
+    url("small-balloons.jpg") 1x,
+    url("large-balloons.jpg") 2x);
+}
+
+<!-- HTML -->
+<div class="box"></div>
+
+```
+
+## Check Options
+
+The default configuration for this check is the following:
+
+```yaml
+DeprecateBgsizes:
+  enabled: true
+```
+
+## When Not To Use It
+
+You should disable this rule in older browsers that don't support the CSS image-set attribute.
+
+## Version
+
+This check has been introduced in Theme Check THEME_CHECK_VERSION.
+
+## Resources
+
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[codesource]: /lib/theme_check/checks/deprecate_bgsizes.rb
+[docsource]: /docs/checks/deprecate_bgsizes.md

--- a/docs/checks/deprecate_lazysizes.md
+++ b/docs/checks/deprecate_lazysizes.md
@@ -1,0 +1,61 @@
+# Deprecate lazySizes (`DeprecateLazysizes`)
+
+[lazysizes](https://github.com/aFarkas/lazysizes) is a common JavaScript library used to lazy load images, iframes and scripts.
+
+## Check Details
+
+This check is aimed at discouraging the use of the lazysizes JavaScript library
+
+:-1: Examples of **incorrect** code for this check:
+
+```liquid
+
+<!-- Reports use of "lazyload" class -->
+<img src="a.jpg" class="lazyload">
+
+<!-- Reports use of "data-srcset" and "data-sizes" attribute. Reports data-sizes="auto" -->
+<img
+  alt="House by the lake"
+  data-sizes="auto"
+  data-srcset="small.jpg 500w,
+  medium.jpg 640w,
+  big.jpg 1024w"
+  data-src="medium.jpg"
+  class="lazyload"
+/>
+
+```
+
+:+1: Examples of **correct** code for this check:
+
+```liquid
+
+<!-- Does not use lazySizes library. Instead uses native "loading" attribute -->
+<img src="a.jpg" loading="lazy">
+
+```
+
+## Check Options
+
+The default configuration for this check is the following:
+
+```yaml
+DeprecateLazysizes:
+  enabled: true
+```
+
+## When Not To Use It
+
+You should disable this rule if you want to support lazy loading of images in older browser that don't support the loading="lazy" attribute yet.
+
+## Version
+
+This check has been introduced in Theme Check THEME_CHECK_VERSION.
+
+## Resources
+
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[codesource]: /lib/theme_check/checks/deprecate_lazysizes.rb
+[docsource]: /docs/checks/deprecate_lazysizes.md

--- a/lib/theme_check/checks/deprecate_bgsizes.rb
+++ b/lib/theme_check/checks/deprecate_bgsizes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module ThemeCheck
+  class DeprecateBgsizes < HtmlCheck
+    severity :suggestion
+    category :html, :performance
+    doc docs_url(__FILE__)
+
+    def on_div(node)
+      class_list = node.attributes["class"]&.value&.split(" ")
+      add_offense("Use the native loading=\"lazy\" attribute instead of lazysizes", node: node) if class_list&.include?("lazyload")
+      add_offense("Use the CSS imageset attribute instead of data-bgset", node: node) if node.attributes["data-bgset"]
+    end
+  end
+end

--- a/lib/theme_check/checks/deprecate_lazysizes.rb
+++ b/lib/theme_check/checks/deprecate_lazysizes.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module ThemeCheck
+  class DeprecateLazysizes < HtmlCheck
+    severity :suggestion
+    category :html, :performance
+    doc docs_url(__FILE__)
+
+    def on_img(node)
+      class_list = node.attributes["class"]&.value&.split(" ")
+      add_offense("Use the native loading=\"lazy\" attribute instead of lazysizes", node: node) if class_list&.include?("lazyload")
+      add_offense("Use the native srcset attribute instead of data-srcset", node: node) if node.attributes["data-srcset"]
+      add_offense("Use the native sizes attribute instead of data-sizes", node: node) if node.attributes["data-sizes"]
+      add_offense("Do not set the data-sizes attribute to auto", node: node) if node.attributes["data-sizes"]&.value == "auto"
+    end
+  end
+end

--- a/lib/theme_check/checks/img_lazy_loading.rb
+++ b/lib/theme_check/checks/img_lazy_loading.rb
@@ -10,12 +10,7 @@ module ThemeCheck
     def on_img(node)
       loading = node.attributes["loading"]&.value&.downcase
       return if ACCEPTED_LOADING_VALUES.include?(loading)
-
-      class_list = node.attributes["class"]&.value&.split(" ")
-
-      if class_list&.include?("lazyload")
-        add_offense("Use the native loading=\"lazy\" attribute instead of lazysizes", node: node)
-      elsif loading == "auto"
+      if loading == "auto"
         add_offense("Prefer loading=\"lazy\" to defer loading of images", node: node)
       else
         add_offense("Add a loading=\"lazy\" attribute to defer loading of images", node: node)

--- a/test/checks/deprecate_bgsizes_test.rb
+++ b/test/checks/deprecate_bgsizes_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class DeprecateBgsizesTest < Minitest::Test
+  def test_valid
+    offenses = analyze_theme(
+      ThemeCheck::DeprecateBgsizes.new,
+      "templates/index.liquid" => <<~END,
+        <div class="other-class"></div>
+      END
+    )
+    assert_offenses("", offenses)
+  end
+
+  def test_reports_data_bgset
+    offenses = analyze_theme(
+      ThemeCheck::DeprecateBgsizes.new,
+      "templates/index.liquid" => <<~END,
+        <div class="lazyload" data-bgset="image-200.jpg [--small] | image-300.jpg [--medium] | image-400.jpg"></div>
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Use the native loading=\"lazy\" attribute instead of lazysizes at templates/index.liquid:1
+      Use the CSS imageset attribute instead of data-bgset at templates/index.liquid:1
+    END
+  end
+end

--- a/test/checks/deprecate_lazysizes_test.rb
+++ b/test/checks/deprecate_lazysizes_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module ThemeCheck
+  class DeprecateLazysizesTest < Minitest::Test
+    def test_valid
+      offenses = analyze_theme(
+        DeprecateLazysizes.new,
+        "templates/index.liquid" => <<~END,
+          <img src="a.jpg" loading="lazy">
+        END
+      )
+      assert_offenses("", offenses)
+    end
+
+    def test_reports_lazyload_class
+      offenses = analyze_theme(
+        DeprecateLazysizes.new,
+        "templates/index.liquid" => <<~END,
+          <img src="a.jpg" class="lazyload">
+          <img src="a.jpg" class="lazyload otherclass">
+        END
+      )
+      assert_offenses(<<~END, offenses)
+        Use the native loading=\"lazy\" attribute instead of lazysizes at templates/index.liquid:1
+        Use the native loading=\"lazy\" attribute instead of lazysizes at templates/index.liquid:2
+      END
+    end
+
+    def test_reports_data_srcset
+      offenses = analyze_theme(
+        DeprecateLazysizes.new,
+        "templates/index.liquid" => <<~END,
+          <img
+            alt="Jellyfish"
+            sizes="(min-width: 1000px) 930px, 90vw"
+            data-srcset="small.jpg 500w,
+            medium.jpg 640w,
+            big.jpg 1024w"
+            data-src="medium.jpg"
+            class="lazyload"
+          />
+        END
+      )
+      assert_offenses(<<~END, offenses)
+        Use the native loading=\"lazy\" attribute instead of lazysizes at templates/index.liquid:1
+        Use the native srcset attribute instead of data-srcset at templates/index.liquid:1
+      END
+    end
+
+    def test_reports_data_sizes
+      offenses = analyze_theme(
+        DeprecateLazysizes.new,
+        "templates/index.liquid" => <<~END,
+          <img
+            alt="House by the lake"
+            data-sizes="(min-width: 1000px) 930px, 90vw"
+            data-srcset="small.jpg 500w,
+            medium.jpg 640w,
+            big.jpg 1024w"
+            data-src="medium.jpg"
+            class="lazyload"
+          />
+        END
+      )
+      assert_offenses(<<~END, offenses)
+        Use the native loading=\"lazy\" attribute instead of lazysizes at templates/index.liquid:1
+        Use the native srcset attribute instead of data-srcset at templates/index.liquid:1
+        Use the native sizes attribute instead of data-sizes at templates/index.liquid:1
+      END
+    end
+
+    def test_reports_sizes_auto
+      offenses = analyze_theme(
+        DeprecateLazysizes.new,
+        "templates/index.liquid" => <<~END,
+          <img
+            alt="House by the lake"
+            data-sizes="auto"
+            data-srcset="small.jpg 500w,
+            medium.jpg 640w,
+            big.jpg 1024w"
+            data-src="medium.jpg"
+            class="lazyload"
+          />
+        END
+      )
+      assert_offenses(<<~END, offenses)
+        Use the native loading=\"lazy\" attribute instead of lazysizes at templates/index.liquid:1
+        Use the native srcset attribute instead of data-srcset at templates/index.liquid:1
+        Use the native sizes attribute instead of data-sizes at templates/index.liquid:1
+        Do not set the data-sizes attribute to auto at templates/index.liquid:1
+      END
+    end
+  end
+end

--- a/test/checks/img_lazy_loading_test.rb
+++ b/test/checks/img_lazy_loading_test.rb
@@ -39,19 +39,5 @@ module ThemeCheck
         Prefer loading="lazy" to defer loading of images at templates/index.liquid:1
       END
     end
-
-    def test_reports_lazysizes
-      offenses = analyze_theme(
-        ImgLazyLoading.new,
-        "templates/index.liquid" => <<~END,
-          <img src="a.jpg" class="lazyload">
-          <img src="a.jpg" class="lazyload otherclass">
-        END
-      )
-      assert_offenses(<<~END, offenses)
-        Use the native loading=\"lazy\" attribute instead of lazysizes at templates/index.liquid:1
-        Use the native loading=\"lazy\" attribute instead of lazysizes at templates/index.liquid:2
-      END
-    end
   end
 end


### PR DESCRIPTION
### What does this do?
Discourages the use of the `lazySizes` Javascript library(https://github.com/aFarkas/lazysizes) and the `bgSizes `plugin (https://github.com/aFarkas/lazysizes/tree/gh-pages/plugins/bgset).
### How does it do it?
Adds the checks `DeprecateLazysizes` and `DeprecateBgsizes`.
### Why did you pick this approach over other options?
Extracting the `lazySizes` check outside of the current `ImgLazyLoading` check allows us to deprecate lazySizes without it affecting the JS "loading" attribute