### PR TITLE
Fix ParsingHelpers#outside_of_strings handling of empty strings

### DIFF
--- a/lib/theme_check/parsing_helpers.rb
+++ b/lib/theme_check/parsing_helpers.rb
@@ -7,8 +7,10 @@ module ThemeCheck
 
       while scanner.scan(/.*?("|')/)
         yield scanner.matched[0..-2]
+        quote = scanner.matched[-1] == "'" ? "'" : "\""
         # Skip to the end of the string
-        scanner.skip_until(scanner.matched[-1] == "'" ? /[^\\]'/ : /[^\\]"/)
+        # Check for empty string first, since follow regexp uses lookahead
+        scanner.skip(quote) || scanner.skip_until(/[^\\]#{quote}/)
       end
 
       yield scanner.rest if scanner.rest?

--- a/test/checks/space_inside_braces_test.rb
+++ b/test/checks/space_inside_braces_test.rb
@@ -283,4 +283,14 @@ class SpaceInsideBracesTest < Minitest::Test
     )
     assert_offenses('', offenses)
   end
+
+  def test_dont_report_missing_spaces_inside_strings
+    offenses = analyze_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {{ filter.min_value.value | money_without_currency | replace: '.', '' | replace: ',', '.' }}
+      END
+    )
+    assert_offenses('', offenses)
+  end
 end

--- a/test/parsing_helpers_test.rb
+++ b/test/parsing_helpers_test.rb
@@ -9,4 +9,13 @@ class ParsingHelpersTest < Minitest::Test
     outside_of_strings("1'\"2'3\"4\"") { |chunk| chunks << chunk }
     assert_equal(["1", "3"], chunks)
   end
+
+  def test_outside_of_strings_with_empty_string
+    chunks = []
+    outside_of_strings("one: '.', '' | two: ',', '.'") { |chunk| chunks << chunk }
+    assert_equal(["one: ", ", ", " | two: ", ", "], chunks)
+    chunks = []
+    outside_of_strings("1'' '2'3") { |chunk| chunks << chunk }
+    assert_equal(["1", " ", "3"], chunks)
+  end
 end


### PR DESCRIPTION
Because lookahead was used in the regex, empty strings were missed in parsing, which caused weird issues such as:

```
template.liquid:100: style: SpaceInsideBraces: Space missing after ','.
        value="{{ filter.min_value.value | money_without_currency | replace: '.', '' | replace: ',', '.' }}"
```