### PR TITLE
Autocorrection `DefaultLocale`

### DIFF
--- a/lib/theme_check/analyzer.rb
+++ b/lib/theme_check/analyzer.rb
@@ -87,6 +87,7 @@ module ThemeCheck
       if @auto_correct
         offenses.each(&:correct)
         @theme.liquid.each(&:write)
+        @theme.json.each(&:write)
       end
     end
 

--- a/lib/theme_check/checks/default_locale.rb
+++ b/lib/theme_check/checks/default_locale.rb
@@ -7,7 +7,9 @@ module ThemeCheck
 
     def on_end
       return if @theme.default_locale_json
-      add_offense("Default translation file not found (for example locales/en.default.json)")
+      add_offense("Default translation file not found (for example locales/en.default.json)") do |corrector|
+        corrector.create_default_locale_json(@theme)
+      end
     end
   end
 end

--- a/lib/theme_check/corrector.rb
+++ b/lib/theme_check/corrector.rb
@@ -31,5 +31,10 @@ module ThemeCheck
     def create(theme, relative_path, content)
       theme.storage.write(relative_path, content)
     end
+
+    def create_default_locale_json(theme)
+      theme.default_locale_json = JsonFile.new('locales/' + theme.default_locale + '.default.json', theme.storage)
+      theme.default_locale_json.create
+    end
   end
 end

--- a/lib/theme_check/corrector.rb
+++ b/lib/theme_check/corrector.rb
@@ -33,8 +33,8 @@ module ThemeCheck
     end
 
     def create_default_locale_json(theme)
-      theme.default_locale_json = JsonFile.new('locales/' + theme.default_locale + '.default.json', theme.storage)
-      theme.default_locale_json.create
+      theme.default_locale_json = JsonFile.new("locales/#{theme.default_locale}.default.json", theme.storage)
+      theme.default_locale_json.update_contents('{}')
     end
   end
 end

--- a/lib/theme_check/json_file.rb
+++ b/lib/theme_check/json_file.rb
@@ -20,6 +20,10 @@ module ThemeCheck
       @parser_error
     end
 
+    def create(content: '{}')
+      @storage.write(relative_path, content)
+    end
+
     def json?
       true
     end

--- a/lib/theme_check/json_file.rb
+++ b/lib/theme_check/json_file.rb
@@ -20,8 +20,15 @@ module ThemeCheck
       @parser_error
     end
 
-    def create(content: '{}')
-      @storage.write(relative_path, content)
+    def update_contents(new_content = '{}')
+      @content = new_content
+    end
+
+    def write
+      if source != @content
+        @storage.write(@relative_path, content)
+        @source = content
+      end
     end
 
     def json?

--- a/lib/theme_check/theme.rb
+++ b/lib/theme_check/theme.rb
@@ -7,7 +7,8 @@ module ThemeCheck
     LIQUID_REGEX = /\.liquid$/i
     JSON_REGEX = /\.json$/i
 
-    attr_accessor :storage
+    attr_reader :storage
+    attr_writer :default_locale_json
 
     def initialize(storage)
       @storage = storage

--- a/test/checks/default_locale_test.rb
+++ b/test/checks/default_locale_test.rb
@@ -17,4 +17,18 @@ class DefaultLocaleTest < Minitest::Test
     )
     refute(offenses.empty?)
   end
+
+  def test_creates_default_file
+    theme = make_theme(
+      "templates/index.liquid" => <<~END,
+        <p>
+          {{1 + 2}}
+        </p>
+      END
+    )
+    analyzer = ThemeCheck::Analyzer.new(theme, [ThemeCheck::DefaultLocale.new], true)
+    analyzer.analyze_theme
+    analyzer.correct_offenses
+    assert(theme.default_locale_json)
+  end
 end


### PR DESCRIPTION
### What does this do?
Makes sure the theme has a default translation file (for example `locales/en.default.json`).
### How does it do it?
Automatically creates the default translation file if it doesn't already exist.
### Why did you pick this approach over other options?
I chose to add a `create_default_locale_json` method to the corrector class to allow for the creation of the default translation files in a corrector block