### PR TITLE
Ignore empty `{{}}` in `SpaceInsideBraces`

### DIFF
--- a/lib/theme_check/checks/space_inside_braces.rb
+++ b/lib/theme_check/checks/space_inside_braces.rb
@@ -51,7 +51,7 @@ module ThemeCheck
     end
 
     def on_variable(node)
-      return if @ignore
+      return if @ignore || node.markup.empty?
       if node.markup[0] != " "
         add_offense("Space missing after '{{'", node: node) do |corrector|
           corrector.insert_before(node, " ")

--- a/test/checks/space_inside_braces_test.rb
+++ b/test/checks/space_inside_braces_test.rb
@@ -293,4 +293,14 @@ class SpaceInsideBracesTest < Minitest::Test
     )
     assert_offenses('', offenses)
   end
+
+  def test_dont_report_empty_variables
+    offenses = analyze_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {{}}
+      END
+    )
+    assert_offenses('', offenses)
+  end
 end


### PR DESCRIPTION
Fixes #348

Also logged a new issue to create a check for this #349. I don't think it's related to `SpacesInsideBraces`, so it should not be in this check.