### PR TITLE
Offending periods

### DIFF
--- a/lib/theme_check/checks/img_width_and_height.rb
+++ b/lib/theme_check/checks/img_width_and_height.rb
@@ -35,7 +35,7 @@ module ThemeCheck
       return unless value =~ ENDS_IN_CSS_UNIT
       value_without_units = value.gsub(ENDS_IN_CSS_UNIT, '')
       add_offense(
-        "The #{attribute} attribute does not take units. Replace with \"#{value_without_units}\".",
+        "The #{attribute} attribute does not take units. Replace with \"#{value_without_units}\"",
         node: node,
       )
     end

--- a/lib/theme_check/checks/remote_asset.rb
+++ b/lib/theme_check/checks/remote_asset.rb
@@ -28,7 +28,7 @@ module ThemeCheck
       return if rel && rel.value != "stylesheet"
 
       add_offense(
-        "Asset should be served by the Shopify CDN for better performance.",
+        "Asset should be served by the Shopify CDN for better performance",
         node: node,
       )
     end


### PR DESCRIPTION
Offense strings shouldn't have a trailing period ("."), since this is added by ThemeCheck::Printer#print when outputting the errors.