### PR TITLE
feature/windows support

### DIFF
--- a/exe/theme-check-language-server.bat
+++ b/exe/theme-check-language-server.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+
+ruby "%~dp0\theme-check-language-server" %*

--- a/exe/theme-check.bat
+++ b/exe/theme-check.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+
+ruby "%~dp0\theme-check" %*

--- a/lib/theme_check/language_server/handler.rb
+++ b/lib/theme_check/language_server/handler.rb
@@ -99,7 +99,7 @@ module ThemeCheck
       end
 
       def path_from_uri(uri)
-        uri&.sub('file://', '')
+        uri&.sub('file://', '')&.sub('/c%3A', '')
       end
 
       def relative_path_from_text_document_uri(params)

--- a/lib/theme_check/language_server/server.rb
+++ b/lib/theme_check/language_server/server.rb
@@ -52,8 +52,19 @@ module ThemeCheck
         response_body = JSON.dump(response)
         log(JSON.pretty_generate(response)) if $DEBUG
 
-        @out.write("Content-Length: #{response_body.bytesize}\r\n")
-        @out.write("\r\n")
+        # Because programming is fun,
+        #
+        # Ruby on Windows turns \n into \r\n. Which means that \r\n
+        # gets turned into \r\r\n. Which means that the protocol
+        # breaks on windows unless we turn STDOUT into binary mode and
+        # set the encoding manually (yuk!) or we do this little hack
+        # here and put \n which gets transformed into \r\n on windows
+        # only...
+        #
+        # Hours wasted: 8.
+        eol = Gem.win_platform? ? "\n" : "\r\n"
+        @out.write("Content-Length: #{response_body.bytesize}#{eol}")
+        @out.write(eol)
         @out.write(response_body)
         @out.flush
       end


### PR DESCRIPTION
- Add Windows support to the language server (prep work for [Shopify/theme-check-vscode#5](https://github.com/Shopify/theme-check-vscode/issues/5))
- Add Windows executables
