### PR TITLE
Change asset size errors into suggestions for theme app extensions

### DIFF
--- a/config/theme_app_extension.yml
+++ b/config/theme_app_extension.yml
@@ -110,11 +110,13 @@ ParserBlockingScriptTag:
 
 AssetSizeJavaScript:
   enabled: true
+  severity: suggestion
   ignore: []
   threshold_in_bytes: 10_000
 
 AssetSizeCSS:
   enabled: true
+  severity: suggestion
   ignore: []
   threshold_in_bytes: 100_000
 
@@ -144,11 +146,13 @@ HtmlParsingError:
 
 AssetSizeAppBlockJavaScript:
   enabled: true
+  severity: suggestion
   ignore: []
   threshold_in_bytes: 10_000
 
 AssetSizeAppBlockCSS:
   enabled: true
+  severity: suggestion
   ignore: []
   threshold_in_bytes: 100_000
 


### PR DESCRIPTION
The JS and CSS asset size limits checks are currently set as `error` severity, with the consequence that they are currently blocking partners from uploading theme app extensions that violate these checks.

The simplest fix for our purposes is to change the severity of the checks to `suggestion`.

Some other possibilities:

* Only change the severity of the app block checks. This would help when a partner is bundling their JS/CSS assets within the extension, but doesn't help when the assets are hosted remotely.
* Only change the severity of these checks when checking theme app extensions.  This would require some code refactoring to allow setting check severity from the configuration file.

Thoughts? (cc @charlespwd, @colinbendell)