### PR TITLE
Add check for forbidden tags in theme app extension blocks

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -178,6 +178,10 @@ AssetSizeAppBlockCSS:
   ignore: []
   threshold_in_bytes: 100_000
 
+AppBlockValidTags:
+  enabled: false
+  ignore: []
+
 PaginationSize:
   enabled: true
   ignore: []

--- a/config/theme_app_extension.yml
+++ b/config/theme_app_extension.yml
@@ -152,6 +152,10 @@ AssetSizeAppBlockCSS:
   ignore: []
   threshold_in_bytes: 100_000
 
+AppBlockValidTags:
+  enabled: true
+  ignore: []
+
 PaginationSize:
   enabled: true
   ignore: []

--- a/docs/checks/app_block_valid_tags.md
+++ b/docs/checks/app_block_valid_tags.md
@@ -1,0 +1,41 @@
+# Reject Invalid Tags for Theme App Extension Blocks (`AppBlockValidTags`)
+
+This rule exists to prevent invalid tags from being used in theme app extension blocks which will be rejected when the theme app extension is promoted.
+
+## Check Details
+
+This rule verifies no invalid tags are used for theme app extension app blocks. Invalid tags include:
+
+- `{% javascript %}`
+- `{% stylesheet %}`
+- `{% include 'foo' %}`
+- `{% layout 'foo' %}`
+- `{% section 'foo' %}`
+
+:-1: **Incorrect** code for this check occurs with the use of any of the above tags in theme app extension blocks.
+
+## Check Options
+
+The default configuration for theme app extensions is the following:
+
+```yaml
+AppBlockValidTags:
+  enabled: true
+```
+
+## When Not To Use It
+
+This rule should not be disabled locally since the check will be enforced when
+promoting new versions of the extension.
+
+## Version
+
+This check has been introduced in THEME_CHECK_VERSION
+
+## Resources
+
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[codesource]: /lib/theme_check/checks/app_block_valid_tags.rb
+[docsource]: /docs/checks/app_block_valid_tags.md

--- a/docs/checks/app_block_valid_tags.md
+++ b/docs/checks/app_block_valid_tags.md
@@ -1,10 +1,10 @@
 # Reject Invalid Tags for Theme App Extension Blocks (`AppBlockValidTags`)
 
-This rule exists to prevent invalid tags from being used in theme app extension blocks which will be rejected when the theme app extension is promoted.
+This rule exists to prevent theme app extension blocks from containing certain tags in their liquid code.
 
 ## Check Details
 
-This rule verifies no invalid tags are used for theme app extension app blocks. Invalid tags include:
+This rule verifies none of the below tags are used in theme app extension blocks.
 
 - `{% javascript %}`
 - `{% stylesheet %}`
@@ -25,8 +25,7 @@ AppBlockValidTags:
 
 ## When Not To Use It
 
-This rule should not be disabled locally since the check will be enforced when
-promoting new versions of the extension.
+This rule should not be disabled locally.
 
 ## Version
 

--- a/docs/checks/app_block_valid_tags.md
+++ b/docs/checks/app_block_valid_tags.md
@@ -1,6 +1,6 @@
-# Reject Invalid Tags for Theme App Extension Blocks (`AppBlockValidTags`)
+# Reject Forbidden Tags from Theme App Extension Blocks (`AppBlockValidTags`)
 
-This rule exists to prevent theme app extension blocks from containing certain tags in their liquid code.
+This rule exists to prevent theme app extension blocks from containing forbidden tags in their liquid code.
 
 ## Check Details
 
@@ -12,7 +12,7 @@ This rule verifies none of the below tags are used in theme app extension blocks
 - `{% layout 'foo' %}`
 - `{% section 'foo' %}`
 
-:-1: **Incorrect** code for this check occurs with the use of any of the above tags in theme app extension blocks.
+:-1: **Incorrect** code for this check occurs with the use of any of the above tags in the liquid code of theme app extension blocks.
 
 ## Check Options
 

--- a/lib/theme_check/checks/app_block_valid_tags.rb
+++ b/lib/theme_check/checks/app_block_valid_tags.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+module ThemeCheck
+  # Reports errors when invalid tags are used in a Theme App
+  # Extension block
+  class AppBlockValidTags < LiquidCheck
+    severity :error
+    category :liquid
+    doc docs_url(__FILE__)
+
+    # Don't allow this check to be disabled with a comment,
+    # since we need to be able to enforce this server-side
+    can_disable false
+
+    OFFENSE_MSG = "Theme app extension blocks cannot contain %s tags"
+
+    def on_javascript(node)
+      add_offense(OFFENSE_MSG % 'javascript', node: node)
+    end
+
+    def on_stylesheet(node)
+      add_offense(OFFENSE_MSG % 'stylesheet', node: node)
+    end
+
+    def on_include(node)
+      add_offense(OFFENSE_MSG % 'include', node: node)
+    end
+
+    def on_layout(node)
+      add_offense(OFFENSE_MSG % 'layout', node: node)
+    end
+
+    def on_section(node)
+      add_offense(OFFENSE_MSG % 'section', node: node)
+    end
+  end
+end

--- a/test/checks/app_block_valid_tags_test.rb
+++ b/test/checks/app_block_valid_tags_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module ThemeCheck
+  class AppBlockValidTagsTest < Minitest::Test
+    def test_include_layout_section_tags
+      ['include', 'layout', 'section'].each do |tag|
+        extension_files = {
+          "blocks/app.liquid" => <<~BLOCK,
+            {% #{tag} 'test' %}
+            {% schema %}
+            { }
+            {% endschema %}
+          BLOCK
+        }
+        offenses = analyze_theme(
+          AppBlockValidTags.new,
+          extension_files,
+        )
+        assert_offenses("Theme app extension blocks cannot contain #{tag} tags at blocks/app.liquid:1", offenses)
+      end
+    end
+
+    def test_javascript_and_stylesheet_tag
+      ['javascript', 'stylesheet'].each do |tag|
+        extension_files = {
+          "blocks/app.liquid" => <<~BLOCK,
+            {% #{tag} %}
+            {% end#{tag} %}
+            {% schema %}
+            { }
+            {% endschema %}
+          BLOCK
+        }
+        offenses = analyze_theme(
+          AppBlockValidTags.new,
+          extension_files,
+        )
+        assert_offenses("Theme app extension blocks cannot contain #{tag} tags at blocks/app.liquid:1", offenses)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/Shopify/theme-check/issues/354

This PR adds a check for the following tags in theme app extension blocks since they will be rejected from the backend:

- `{% javascript %}` 
- `{% stylesheet %}`
- `{% include %}`
- `{% section %}`
- `{% layout %}`