### PR TITLE
Fix newline in outside_of_strings

### DIFF
--- a/lib/theme_check/checks.rb
+++ b/lib/theme_check/checks.rb
@@ -29,8 +29,18 @@ module ThemeCheck
     def call_check_method(check, method, *args)
       return unless check.respond_to?(method) && !check.ignored?
 
-      Timeout.timeout(CHECK_METHOD_TIMEOUT) do
+      # If you want to use binding.pry in unit tests, define the
+      # THEME_CHECK_DEBUG environment variable. e.g.
+      #
+      #   $ export THEME_CHECK_DEBUG=true
+      #   $ bundle exec rake tests:in_memory
+      #
+      if ENV['THEME_CHECK_DEBUG']
         check.send(method, *args)
+      else
+        Timeout.timeout(CHECK_METHOD_TIMEOUT) do
+          check.send(method, *args)
+        end
       end
     rescue Liquid::Error
       # Pass-through Liquid errors

--- a/lib/theme_check/checks/space_inside_braces.rb
+++ b/lib/theme_check/checks/space_inside_braces.rb
@@ -57,7 +57,7 @@ module ThemeCheck
           corrector.insert_before(node, " ")
         end
       end
-      if node.markup[-1] != " "
+      if node.markup[-1] != " " && node.markup[-1] != "\n"
         add_offense("Space missing before '}}'", node: node) do |corrector|
           corrector.insert_after(node, " ")
         end

--- a/lib/theme_check/parsing_helpers.rb
+++ b/lib/theme_check/parsing_helpers.rb
@@ -5,7 +5,7 @@ module ThemeCheck
     def outside_of_strings(markup)
       scanner = StringScanner.new(markup)
 
-      while scanner.scan(/.*?("|')/)
+      while scanner.scan(/.*?("|')/m)
         yield scanner.matched[0..-2]
         quote = scanner.matched[-1] == "'" ? "'" : "\""
         # Skip to the end of the string

--- a/test/checks/space_inside_braces_test.rb
+++ b/test/checks/space_inside_braces_test.rb
@@ -289,6 +289,15 @@ class SpaceInsideBracesTest < Minitest::Test
       ThemeCheck::SpaceInsideBraces.new,
       "templates/index.liquid" => <<~END,
         {{ filter.min_value.value | money_without_currency | replace: '.', '' | replace: ',', '.' }}
+        {{ paginate | default_pagination:
+          next: '<i class="icon icon--right-t"></i><span class="icon-fallback__text">Next Page</span>',
+          previous: '<i class="icon icon--left-t"></i><span class="icon-fallback__text">Previous Page</span>'
+        }}
+        {%
+          render: "my-card",
+          classname: "h-full md:hidden",
+          image: block.settings.mobile-image
+        %}
       END
     )
     assert_offenses('', offenses)

--- a/test/parsing_helpers_test.rb
+++ b/test/parsing_helpers_test.rb
@@ -18,4 +18,13 @@ class ParsingHelpersTest < Minitest::Test
     outside_of_strings("1'' '2'3") { |chunk| chunks << chunk }
     assert_equal(["1", " ", "3"], chunks)
   end
+
+  def test_outside_of_strings_with_newline
+    chunks = []
+    outside_of_strings(<<~CONTENTS) { |chunk| chunks << chunk }
+      next: '<i class="icon icon--right-t"></i><span class="icon-fallback__text">Next Page</span>',
+      previous: '<i class="icon icon--left-t"></i><span class="icon-fallback__text">Previous Page</span>'
+    CONTENTS
+    assert_equal(["next: ", ",\nprevious: ", "\n"], chunks)
+  end
 end


### PR DESCRIPTION
Fixes #376
Fixes #365

The regex was not multiline, so the scanner wasn't properly splitting the string.
