### PR TITLE
Autocorrection `MissingRequiredTemplateFiles`

### DIFF
--- a/lib/theme_check/checks/missing_required_template_files.rb
+++ b/lib/theme_check/checks/missing_required_template_files.rb
@@ -9,19 +9,33 @@ module ThemeCheck
     doc docs_url(__FILE__)
 
     REQUIRED_LIQUID_FILES = %w(layout/theme)
-    REQUIRED_TEMPLATE_FILES = %w(
-      index product collection cart blog article page list-collections search 404
+
+    REQUIRED_LIQUID_TEMPLATE_FILES = %w(
       gift_card customers/account customers/activate_account customers/addresses
-      customers/login customers/order customers/register customers/reset_password password
-    )
-      .map { |file| "templates/#{file}" }
+      customers/login customers/order customers/register customers/reset_password
+    ).map { |file| "templates/#{file}" }
+
+    REQUIRED_JSON_TEMPLATE_FILES = %w(
+      index product collection cart blog article page list-collections search 404
+      password
+    ).map { |file| "templates/#{file}" }
+
+    REQUIRED_TEMPLATE_FILES = (REQUIRED_LIQUID_TEMPLATE_FILES + REQUIRED_JSON_TEMPLATE_FILES)
 
     def on_end
       (REQUIRED_LIQUID_FILES - theme.liquid.map(&:name)).each do |file|
-        add_offense("'#{file}.liquid' is missing")
+        add_offense("'#{file}.liquid' is missing") do |corrector|
+          corrector.create(@theme, "#{file}.liquid", "")
+        end
       end
       (REQUIRED_TEMPLATE_FILES - (theme.liquid + theme.json).map(&:name)).each do |file|
-        add_offense("'#{file}.liquid' or '#{file}.json' is missing")
+        add_offense("'#{file}.liquid' or '#{file}.json' is missing") do |corrector|
+          if REQUIRED_LIQUID_TEMPLATE_FILES.include?(file)
+            corrector.create(@theme, "#{file}.liquid", "")
+          else
+            corrector.create(@theme, "#{file}.json", "")
+          end
+        end
       end
     end
   end

--- a/test/checks/missing_required_template_files_test.rb
+++ b/test/checks/missing_required_template_files_test.rb
@@ -77,4 +77,45 @@ class MissingRequiredTemplateFilesTest < Minitest::Test
 
     assert_offenses("", offenses)
   end
+
+  def test_creates_missing_layout_theme_file
+    theme = make_theme(
+      "templates/index.liquid" => "",
+      "templates/product.liquid" => "",
+    )
+
+    analyzer = ThemeCheck::Analyzer.new(theme, [ThemeCheck::MissingRequiredTemplateFiles.new], true)
+    analyzer.analyze_theme
+    analyzer.correct_offenses
+
+    assert(theme.storage.files.include?("layout/theme.liquid"))
+  end
+
+  def test_creates_missing_template_files
+    theme = make_theme(
+      "layout/theme.liquid" => "",
+      "templates/index.json" => "",
+      "templates/collection.json" => "",
+      "templates/cart.json" => "",
+      "templates/blog.json" => "",
+      "templates/article.json" => "",
+      "templates/page.json" => "",
+      "templates/list-collections.json" => "",
+      "templates/404.json" => "",
+      "templates/customers/account.liquid" => "",
+      "templates/customers/activate_account.liquid" => "",
+      "templates/customers/addresses.liquid" => "",
+      "templates/customers/order.liquid" => "",
+      "templates/customers/register.liquid" => "",
+      "templates/customers/reset_password.liquid" => "",
+    )
+
+    missing_files = ["templates/product.json", "templates/search.json", "templates/customers/login.liquid", "templates/password.json", "templates/gift_card.liquid"]
+
+    analyzer = ThemeCheck::Analyzer.new(theme, [ThemeCheck::MissingRequiredTemplateFiles.new], true)
+    analyzer.analyze_theme
+    analyzer.correct_offenses
+
+    assert(missing_files.all? { |file| theme.storage.files.include?(file) })
+  end
 end


### PR DESCRIPTION
### What does this do?
Makes sure all of the required template files in a theme are present.
### How does it do it?
Automatically creates required template files if they don't already exist.
### Why did you pick this approach over other options?
This approach uses methods on the corrector class to create the template files that are missing