### PR TITLE
Correctly highlight substrings inside nodes

### DIFF
--- a/lib/theme_check/check.rb
+++ b/lib/theme_check/check.rb
@@ -91,8 +91,8 @@ module ThemeCheck
       @offenses ||= []
     end
 
-    def add_offense(message, node: nil, template: node&.template, markup: nil, line_number: nil, &block)
-      offenses << Offense.new(check: self, message: message, template: template, node: node, markup: markup, line_number: line_number, correction: block)
+    def add_offense(message, node: nil, template: node&.template, markup: nil, line_number: nil, node_markup_offset: 0, &block)
+      offenses << Offense.new(check: self, message: message, template: template, node: node, markup: markup, line_number: line_number, node_markup_offset: node_markup_offset, correction: block)
     end
 
     def severity

--- a/lib/theme_check/checks/space_inside_braces.rb
+++ b/lib/theme_check/checks/space_inside_braces.rb
@@ -14,18 +14,38 @@ module ThemeCheck
       return unless node.markup
       return if :assign == node.type_name
 
-      outside_of_strings(node.markup) do |chunk|
+      outside_of_strings(node.markup) do |chunk, chunk_start|
         chunk.scan(/([,:|]|==|<>|<=|>=|<|>|!=)  +/) do |_match|
-          add_offense("Too many spaces after '#{Regexp.last_match(1)}'", node: node, markup: Regexp.last_match(0))
+          add_offense(
+            "Too many spaces after '#{Regexp.last_match(1)}'",
+            node: node,
+            markup: Regexp.last_match(0),
+            node_markup_offset: chunk_start + Regexp.last_match.begin(0)
+          )
         end
         chunk.scan(/([,:|]|==|<>|<=|>=|<\b|>\b|!=)(\S|\z)/) do |_match|
-          add_offense("Space missing after '#{Regexp.last_match(1)}'", node: node, markup: Regexp.last_match(0))
+          add_offense(
+            "Space missing after '#{Regexp.last_match(1)}'",
+            node: node,
+            markup: Regexp.last_match(0),
+            node_markup_offset: chunk_start + Regexp.last_match.begin(0),
+          )
         end
         chunk.scan(/  (\||==|<>|<=|>=|<|>|!=)+/) do |_match|
-          add_offense("Too many spaces before '#{Regexp.last_match(1)}'", node: node, markup: Regexp.last_match(0))
+          add_offense(
+            "Too many spaces before '#{Regexp.last_match(1)}'",
+            node: node,
+            markup: Regexp.last_match(0),
+            node_markup_offset: chunk_start + Regexp.last_match.begin(0)
+          )
         end
         chunk.scan(/(\A|\S)(?<match>\||==|<>|<=|>=|<|\b>|!=)/) do |_match|
-          add_offense("Space missing before '#{Regexp.last_match(1)}'", node: node, markup: Regexp.last_match(0))
+          add_offense(
+            "Space missing before '#{Regexp.last_match(1)}'",
+            node: node,
+            markup: Regexp.last_match(0),
+            node_markup_offset: chunk_start + Regexp.last_match.begin(0)
+          )
         end
       end
     end

--- a/lib/theme_check/node.rb
+++ b/lib/theme_check/node.rb
@@ -127,7 +127,11 @@ module ThemeCheck
     end
 
     def position
-      @position ||= Position.new(markup, template&.source, line_number)
+      @position ||= Position.new(
+        markup,
+        template&.source,
+        line_number_1_indexed: line_number
+      )
     end
 
     def start_index

--- a/lib/theme_check/parsing_helpers.rb
+++ b/lib/theme_check/parsing_helpers.rb
@@ -6,14 +6,15 @@ module ThemeCheck
       scanner = StringScanner.new(markup)
 
       while scanner.scan(/.*?("|')/m)
-        yield scanner.matched[0..-2]
+        chunk_start = scanner.pre_match.size
+        yield scanner.matched[0..-2], chunk_start
         quote = scanner.matched[-1] == "'" ? "'" : "\""
         # Skip to the end of the string
         # Check for empty string first, since follow regexp uses lookahead
         scanner.skip(/#{quote}/) || scanner.skip_until(/[^\\]#{quote}/)
       end
 
-      yield scanner.rest if scanner.rest?
+      yield scanner.rest, scanner.charpos if scanner.rest?
     end
   end
 end

--- a/test/checks/space_inside_braces_test.rb
+++ b/test/checks/space_inside_braces_test.rb
@@ -303,6 +303,22 @@ class SpaceInsideBracesTest < Minitest::Test
     assert_offenses('', offenses)
   end
 
+  def test_reports_properly
+    offenses = analyze_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {{ 'a' | replace: ', ',',' | split: ',' }}
+        0000000000111111111122222222223333333333
+        0123456789012345678901234567890123456789
+        The two lines above are there to help identify the index
+      END
+    )
+    assert_offenses_with_range(
+      "Space missing after ',' at templates/index.liquid:22:23",
+      offenses
+    )
+  end
+
   def test_dont_report_empty_variables
     offenses = analyze_theme(
       ThemeCheck::SpaceInsideBraces.new,

--- a/test/position_test.rb
+++ b/test/position_test.rb
@@ -12,7 +12,7 @@ module ThemeCheck
     end
 
     def test_positions_are_valid
-      position = Position.new('23', @contents, 2)
+      position = Position.new('23', @contents, line_number_1_indexed: 2)
       assert_equal(5 + 2, position.start_index)
       assert_equal(5 + 4, position.end_index)
       assert_equal(1, position.start_row)
@@ -20,7 +20,7 @@ module ThemeCheck
       assert_equal(1, position.end_row)
       assert_equal(4, position.end_column)
 
-      position = Position.new("3\n01", @contents, 2)
+      position = Position.new("3\n01", @contents, line_number_1_indexed: 2)
       assert_equal(5 + 3, position.start_index)
       assert_equal(5 + 5 + 2, position.end_index)
       assert_equal(1, position.start_row)
@@ -29,9 +29,31 @@ module ThemeCheck
       assert_equal(2, position.end_column)
     end
 
+    def test_reports_content_inside_node_markup_properly
+      node_markup = "{{ var | replace ', ','#' }}"
+      needle = ','
+      contents = "\n" + node_markup
+      # Left here as a visual guide to understand the indexes
+      # "\n{{ var | replace ', ','#' }}"
+      #   01234567890123456789012345678
+      #   00123456789012345678901234567
+      position = Position.new(
+        needle,
+        contents,
+        node_markup: node_markup,
+        node_markup_offset: 20,
+      )
+      assert_equal(22, position.start_index)
+      assert_equal(22 + needle.size, position.end_index)
+      assert_equal(1, position.start_row)
+      assert_equal(21, position.start_column)
+      assert_equal(1, position.end_row)
+      assert_equal(21 + needle.size, position.end_column)
+    end
+
     # Can't find needle = highlight line
     def test_cant_find_needle
-      position = Position.new("nope", @contents, 2)
+      position = Position.new("nope", @contents, line_number_1_indexed: 2)
       assert_equal(5, position.start_index)
       assert_equal(9, position.end_index)
       assert_equal(1, position.start_row)
@@ -41,7 +63,7 @@ module ThemeCheck
     end
 
     def test_line_number_too_small_returns_first_line
-      position = Position.new(nil, @contents, -1)
+      position = Position.new(nil, @contents, line_number_1_indexed: -1)
       assert_equal(0, position.start_index)
       assert_equal(4, position.end_index)
       assert_equal(0, position.start_row)
@@ -49,7 +71,7 @@ module ThemeCheck
       assert_equal(0, position.end_row)
       assert_equal(4, position.end_column)
 
-      position = Position.new("nope", @contents, -1)
+      position = Position.new("nope", @contents, line_number_1_indexed: -1)
       assert_equal(0, position.start_index)
       assert_equal(4, position.end_index)
       assert_equal(0, position.start_row)
@@ -59,7 +81,7 @@ module ThemeCheck
     end
 
     def test_line_number_too_large_returns_last_line
-      position = Position.new(nil, @contents, 150)
+      position = Position.new(nil, @contents, line_number_1_indexed: 150)
       assert_equal(5 + 5, position.start_index)
       assert_equal(5 + 5 + 4, position.end_index)
       assert_equal(2, position.start_row)
@@ -67,7 +89,7 @@ module ThemeCheck
       assert_equal(2, position.end_row)
       assert_equal(3, position.end_column)
 
-      position = Position.new("nope", @contents, 150)
+      position = Position.new("nope", @contents, line_number_1_indexed: 150)
       assert_equal(5 + 5, position.start_index)
       assert_equal(5 + 5 + 4, position.end_index)
       assert_equal(2, position.start_row)
@@ -78,7 +100,7 @@ module ThemeCheck
 
     # No contents = [0,0]
     def test_positions_handles_missing_content_gracefully
-      position = Position.new('23', nil, 2)
+      position = Position.new('23', nil, line_number_1_indexed: 2)
       assert_equal(0, position.start_index)
       assert_equal(0, position.end_index)
       assert_equal(0, position.start_row)
@@ -89,7 +111,7 @@ module ThemeCheck
 
     # Missing needle = highlight line
     def test_positions_handles_missing_needle_gracefully
-      position = Position.new(nil, @contents, 2)
+      position = Position.new(nil, @contents, line_number_1_indexed: 2)
       assert_equal(5, position.start_index)
       assert_equal(9, position.end_index)
       assert_equal(1, position.start_row)
@@ -100,7 +122,7 @@ module ThemeCheck
 
     # Missing line number = first occurence of markup in string
     def test_positions_handles_missing_line_number_gracefully
-      position = Position.new('23', @contents, nil)
+      position = Position.new('23', @contents, line_number_1_indexed: nil)
       assert_equal(2, position.start_index)
       assert_equal(4, position.end_index)
       assert_equal(0, position.start_row)
@@ -111,7 +133,7 @@ module ThemeCheck
 
     # Missing needle + contents = [0, 0]
     def test_positions_handles_missing_needle_and_content_gracefully
-      position = Position.new(nil, nil, 2)
+      position = Position.new(nil, nil, line_number_1_indexed: 2)
       assert_equal(0, position.start_index)
       assert_equal(0, position.end_index)
       assert_equal(0, position.start_row)
@@ -122,7 +144,7 @@ module ThemeCheck
 
     # Missing needle + line_number = [0, 0]
     def test_positions_handles_missing_needle_and_line_number_gracefully
-      position = Position.new(nil, @contents, nil)
+      position = Position.new(nil, @contents, line_number_1_indexed: nil)
       assert_equal(0, position.start_index)
       assert_equal(0, position.end_index)
       assert_equal(0, position.start_row)
@@ -133,7 +155,7 @@ module ThemeCheck
 
     # Missing contents + line_number = [0, 0]
     def test_positions_handles_missing_contents_and_line_number_gracefully
-      position = Position.new('23', nil, nil)
+      position = Position.new('23', nil, line_number_1_indexed: nil)
       assert_equal(0, position.start_index)
       assert_equal(0, position.end_index)
       assert_equal(0, position.start_row)
@@ -143,7 +165,7 @@ module ThemeCheck
     end
 
     def test_missing_everything
-      position = Position.new(nil, nil, nil)
+      position = Position.new(nil, nil, line_number_1_indexed: nil)
       assert_equal(0, position.start_index)
       assert_equal(0, position.end_index)
       assert_equal(0, position.start_row)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -70,6 +70,24 @@ module Minitest
       assert_equal(output.chomp, offenses.sort_by(&:location).join("\n"))
     end
 
+    def assert_offenses_with_range(output, offenses)
+      # Making sure nothing blows up in the language_server
+      offenses.each do |offense|
+        assert(offense.start_line)
+        assert(offense.start_column)
+        assert(offense.end_line)
+        assert(offense.end_column)
+      end
+
+      assert_equal(
+        output.chomp,
+        offenses
+          .sort_by(&:location_range)
+          .map(&:to_s_range)
+          .join("\n")
+      )
+    end
+
     def assert_includes_offense(offenses, output)
       assert_includes(offenses.sort_by(&:location).join("\n"), output.chomp)
     end


### PR DESCRIPTION
Fixes #376

If a node's content is the following:

```liquid
{{ var | replace ',',', ' }}`
```

Then, our SpaceInsideBraces check should be able to highlight the second comma inside this string.

Since the markup we're trying to highlight is `,`, and since Liquid only provides _line_ numbers. We needed another mechanism to be able to identify substrings of nodes as offenses.
