### PR TITLE
Add `MissingTemplate` `ignore_missing` option

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -23,6 +23,7 @@ LiquidTag:
 MissingTemplate:
   enabled: true
   ignore: []
+  ignore_missing: []
 
 NestedSnippet:
   enabled: true

--- a/config/theme_app_extension.yml
+++ b/config/theme_app_extension.yml
@@ -23,6 +23,7 @@ LiquidTag:
 MissingTemplate:
   enabled: true
   ignore: []
+  ignore_missing: []
 
 NestedSnippet:
   enabled: true

--- a/docs/checks/missing_template.md
+++ b/docs/checks/missing_template.md
@@ -25,7 +25,32 @@ The default configuration for this check is the following:
 ```yaml
 MissingTemplate:
   enabled: true
+  ignore_missing: []
 ```
+
+### `ignore_missing`
+
+Specify a list of patterns of missing template files to ignore.
+
+While the `ignore` option will ignore all occurrences of `MissingTemplate` according to the file in which they appear, `ignore_missing` allows ignoring all occurrences of `MissingTemplate` based on the target template, the template being rendered.
+
+For example:
+
+```yaml
+MissingTemplate:
+  ignore_missing:
+  - snippets/icon-*
+```
+
+Would ignore offenses on `{% render 'icon-missing' %}` across all theme files.
+
+```yaml
+MissingTemplate:
+  ignore:
+  - templates/index.liquid
+```
+
+Would ignore all `MissingTemplate` in `templates/index.liquid`, no mater the file being rendered.
 
 ## Version
 

--- a/lib/theme_check/checks/missing_template.rb
+++ b/lib/theme_check/checks/missing_template.rb
@@ -7,20 +7,33 @@ module ThemeCheck
     doc docs_url(__FILE__)
     single_file false
 
+    def initialize(ignore_missing: [])
+      @ignore_missing = ignore_missing
+    end
+
     def on_include(node)
       template = node.value.template_name_expr
       if template.is_a?(String)
-        unless theme["snippets/#{template}"]
-          add_offense("'snippets/#{template}.liquid' is not found", node: node)
-        end
+        add_missing_offense("snippets/#{template}", node: node)
       end
     end
     alias_method :on_render, :on_include
 
     def on_section(node)
       template = node.value.section_name
-      unless theme["sections/#{template}"]
-        add_offense("'sections/#{template}.liquid' is not found", node: node)
+      add_missing_offense("sections/#{template}", node: node)
+    end
+
+    private
+
+    def ignore?(path)
+      @ignore_missing.any? { |pattern| File.fnmatch?(pattern, path) }
+    end
+
+    def add_missing_offense(name, node:)
+      path = "#{name}.liquid"
+      unless ignore?(path) || theme[name]
+        add_offense("'#{path}' is not found", node: node)
       end
     end
   end

--- a/test/checks/missing_template_test.rb
+++ b/test/checks/missing_template_test.rb
@@ -57,4 +57,18 @@ class MissingTemplateTest < Minitest::Test
     )
     assert_offenses("", offenses)
   end
+
+  def test_ignore_missing
+    offenses = analyze_theme(
+      ThemeCheck::MissingTemplate.new(ignore_missing: [
+        "snippets/icon-*",
+        "sections/*",
+      ]),
+      "templates/index.liquid" => <<~END,
+        {% render 'icon-nope' %}
+        {% section 'anything' %}
+      END
+    )
+    assert_offenses("", offenses)
+  end
 end


### PR DESCRIPTION
Fixes #373

Can be a bit confusing w/ the other `ignore`, so I added an example. Hopefully I made it clear enough in the docs.