### PR TITLE
Fixup windows executable duplication

### DIFF
--- a/exe/theme-check-language-server.bat
+++ b/exe/theme-check-language-server.bat
@@ -1,3 +1,0 @@
-@ECHO OFF
-
-ruby "%~dp0\theme-check-language-server" %*

--- a/exe/theme-check.bat
+++ b/exe/theme-check.bat
@@ -1,3 +1,0 @@
-@ECHO OFF
-
-ruby "%~dp0\theme-check" %*


### PR DESCRIPTION
Turns out that the Gemspec's executables option makes the .bat files for us.

I've tested this works properly on windows by doing the following:

1. Deleting the files and committing the delete
2. `gem build theme-check.gemspec`
3. `gem install --bindir bin2 --local theme-check`
4. `dir bin2`, making sure that there aren't 2 .bat.bat files and that the .bat files work properly.

Fixes #371