### PR TITLE
Add check for global app block type in theme sections

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -188,3 +188,6 @@ PaginationSize:
   ignore: []
   min_size: 1
   max_size: 50
+
+DeprecatedGlobalAppBlockType:
+  enabled: true

--- a/docs/checks/deprecated_global_app_block_type.md
+++ b/docs/checks/deprecated_global_app_block_type.md
@@ -1,0 +1,65 @@
+# Check for deprecated global app block type `@global`
+This check makes sure theme sections are not using [deprecated (`@global`)][change_log] global app block type.
+
+## Check Details
+In order for theme sections to [support app blocks][support_app_blocks_in_theme_section], sections need to define a block of type `@app`. This check makes sure that theme sections are not using the deprecated (`@global`) global app block type in theme sections.
+
+:-1: Example of **incorrect** theme section for this check:
+```
+{% for block in section.blocks %}
+  {% if block.type = "@global" %}
+    {% render block %}
+  {% endif %}
+{% endfor %}
+
+{% schema %}
+{
+  "name": "Product section",
+  "blocks": [{"type": "@global"}]
+}
+{% endschema %}
+```
+
+:+1: Examples of **correct** theme section for this check:
+```
+{% for block in section.blocks %}
+  {% if block.type = "@app" %}
+    {% render block %}
+  {% endif %}
+{% endfor %}
+
+{% schema %}
+{
+  "name": "Product section",
+  "blocks": [{"type": "@app"}]
+}
+{% endschema %}
+```
+
+## Check Options
+
+The default configuration for this check is the following:
+
+```yaml
+DeprecatedGlobalAppBlockType:
+  enabled: true
+```
+
+## When Not To Use It
+
+It is discouraged to disable this check.
+
+## Version
+
+This check has been introduced in Theme Check THEME_CHECK_VERSION.
+
+## Resources
+
+- [Rule Source][codesource]
+- [Documentation Source][docsource]
+
+[codesource]: /lib/theme_check/checks/deprecated_global_app_block_type.rb
+[docsource]: /docs/checks/deprecated_global_app_block_type.md
+[remote_asset]: /docs/checks/deprecated_global_app_block_type.md
+[support_app_blocks_in_theme_section]: https://shopify.dev/themes/migration#step-8-add-support-for-app-blocks-to-sections
+[change_log]: https://shopify.dev/changelog/removing-the-global-block-type-in-favour-of-the-app-block-type-in-theme-sections

--- a/lib/theme_check/checks/deprecated_global_app_block_type.rb
+++ b/lib/theme_check/checks/deprecated_global_app_block_type.rb
@@ -21,19 +21,35 @@ module ThemeCheck
       # Ignored, handled in ValidSchema.
     end
 
-    def on_string(node)
+    def on_case(node)
       if node.value == INVALID_GLOBAL_APP_BLOCK_TYPE
-        add_offense(
-          "Deprecated '#{INVALID_GLOBAL_APP_BLOCK_TYPE}' block type, use '#{VALID_GLOBAL_APP_BLOCK_TYPE}' block type instead.",
-          node: node
-        )
+        report_offense(node)
+      end
+    end
+
+    def on_condition(node)
+      if node.value.right == INVALID_GLOBAL_APP_BLOCK_TYPE || node.value.left == INVALID_GLOBAL_APP_BLOCK_TYPE
+        report_offense(node)
+      end
+    end
+
+    def on_variable(node)
+      if node.value.name == INVALID_GLOBAL_APP_BLOCK_TYPE
+        report_offense(node)
       end
     end
 
     private
 
+    def report_offense(node)
+      add_offense(
+        "Deprecated '#{INVALID_GLOBAL_APP_BLOCK_TYPE}' block type, use '#{VALID_GLOBAL_APP_BLOCK_TYPE}' block type instead.",
+        node: node
+      )
+    end
+
     def block_types_from(schema)
-      schema["blocks"].map do |block|
+      schema.fetch("blocks", []).map do |block|
         block.fetch("type", "")
       end
     end

--- a/lib/theme_check/checks/deprecated_global_app_block_type.rb
+++ b/lib/theme_check/checks/deprecated_global_app_block_type.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+module ThemeCheck
+  class DeprecatedGlobalAppBlockType < LiquidCheck
+    severity :error
+    category :liquid
+    doc docs_url(__FILE__)
+
+    INVALID_GLOBAL_APP_BLOCK_TYPE = "@global"
+    VALID_GLOBAL_APP_BLOCK_TYPE = "@app"
+
+    def on_schema(node)
+      schema = JSON.parse(node.value.nodelist.join)
+
+      if block_types_from(schema).include?(INVALID_GLOBAL_APP_BLOCK_TYPE)
+        add_offense(
+          "Deprecated '#{INVALID_GLOBAL_APP_BLOCK_TYPE}' block type defined in the schema, use '#{VALID_GLOBAL_APP_BLOCK_TYPE}' block type instead.",
+          node: node
+        )
+      end
+    rescue JSON::ParserError
+      # Ignored, handled in ValidSchema.
+    end
+
+    def on_string(node)
+      if node.value == INVALID_GLOBAL_APP_BLOCK_TYPE
+        add_offense(
+          "Deprecated '#{INVALID_GLOBAL_APP_BLOCK_TYPE}' block type, use '#{VALID_GLOBAL_APP_BLOCK_TYPE}' block type instead.",
+          node: node
+        )
+      end
+    end
+
+    private
+
+    def block_types_from(schema)
+      schema["blocks"].map do |block|
+        block.fetch("type", "")
+      end
+    end
+  end
+end

--- a/test/checks/deprecated_global_app_block_type_test.rb
+++ b/test/checks/deprecated_global_app_block_type_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module ThemeCheck
+  class DeprecatedGlobalAppBlockTypeTest < Minitest::Test
+    def test_reject_invalid_global_app_block_type_in_section_schemas
+      offenses = analyze_theme(
+        ThemeCheck::DeprecatedGlobalAppBlockType.new,
+        "sections/product.liquid" => <<~END,
+          {% schema %}
+            {
+              "name": "Product section",
+              "blocks": [{"type": "@global"}]
+            }
+          {% endschema %}
+        END
+      )
+
+      assert_offenses(<<~END, offenses)
+        Deprecated '@global' block type defined in the schema, use '@app' block type instead. at sections/product.liquid:1
+      END
+    end
+
+    def test_reject_invalid_global_app_block_type_in_the_section_body
+      offenses = analyze_theme(
+        ThemeCheck::DeprecatedGlobalAppBlockType.new,
+        "sections/product.liquid" => <<~END,
+          {% for block in section.blocks %}
+            {% if block.type = "@global" %}
+              {% render block %}
+            {% endif %}
+          {% endfor %}
+          {% schema %}
+            {
+              "name": "Product section",
+              "blocks": [{"type": "@global"}]
+            }
+          {% endschema %}
+        END
+      )
+
+      assert_offenses(<<~END, offenses)
+        Deprecated '@global' block type, use '@app' block type instead. at sections/product.liquid
+        Deprecated '@global' block type defined in the schema, use '@app' block type instead. at sections/product.liquid:6
+      END
+    end
+
+    def test_accepts_valid_global_app_block_type
+      offenses = analyze_theme(
+        ThemeCheck::DeprecatedGlobalAppBlockType.new,
+        "sections/product.liquid" => <<~END,
+          {% for block in section.blocks %}
+            {% if block.type = "@app" %}
+              {% render block %}
+            {% endif %}
+          {% endfor %}
+          {% schema %}
+            {
+              "name": "Product section",
+              "blocks": [{"type": "@app"}]
+            }
+          {% endschema %}
+        END
+      )
+
+      assert_offenses("", offenses)
+    end
+  end
+end

--- a/test/checks/deprecated_global_app_block_type_test.rb
+++ b/test/checks/deprecated_global_app_block_type_test.rb
@@ -20,13 +20,14 @@ module ThemeCheck
       END
     end
 
-    def test_reject_invalid_global_app_block_type_in_the_section_body
+    def test_reject_invalid_global_app_block_type_in_conditional_statement
       offenses = analyze_theme(
         ThemeCheck::DeprecatedGlobalAppBlockType.new,
         "sections/product.liquid" => <<~END,
           {% for block in section.blocks %}
             {% if block.type = "@global" %}
               {% render block %}
+            {% elsif "@global" == block.type %}
             {% endif %}
           {% endfor %}
           {% schema %}
@@ -40,8 +41,71 @@ module ThemeCheck
 
       assert_offenses(<<~END, offenses)
         Deprecated '@global' block type, use '@app' block type instead. at sections/product.liquid
-        Deprecated '@global' block type defined in the schema, use '@app' block type instead. at sections/product.liquid:6
+        Deprecated '@global' block type, use '@app' block type instead. at sections/product.liquid
+        Deprecated '@global' block type defined in the schema, use '@app' block type instead. at sections/product.liquid:7
       END
+    end
+
+    def test_reject_invalid_global_app_block_type_in_switch_case_statement
+      offenses = analyze_theme(
+        ThemeCheck::DeprecatedGlobalAppBlockType.new,
+        "sections/product.liquid" => <<~END,
+          {% for block in section.blocks %}
+            {% case block.type %}
+              {% when "@global" %}
+                {% render block %}
+              {% else %}
+            {% endcase %}
+          {% endfor %}
+          {% schema %}
+            {
+              "name": "Product section",
+              "blocks": [{"type": "@global"}]
+            }
+          {% endschema %}
+        END
+      )
+
+      assert_offenses(<<~END, offenses)
+        Deprecated '@global' block type, use '@app' block type instead. at sections/product.liquid
+        Deprecated '@global' block type defined in the schema, use '@app' block type instead. at sections/product.liquid:8
+      END
+    end
+
+    def test_reject_invalid_global_app_block_type_defined_as_liquid_variable
+      offenses = analyze_theme(
+        ThemeCheck::DeprecatedGlobalAppBlockType.new,
+        "sections/product.liquid" => <<~END,
+          {% assign invalid = "@global" %}
+          {% assign valid = "@app" %}
+          {% schema %}
+            {
+              "name": "Product section"
+            }
+          {% endschema %}
+        END
+      )
+
+      assert_offenses(<<~END, offenses)
+        Deprecated '@global' block type, use '@app' block type instead. at sections/product.liquid:1
+      END
+    end
+
+    def test_does_not_reject_global_string_used_outside_liquid_control_flow_statements
+      offenses = analyze_theme(
+        ThemeCheck::DeprecatedGlobalAppBlockType.new,
+        "sections/product.liquid" => <<~END,
+          <p> This is "@global" </p>
+          <script> var i = "@global" </script>
+          {% schema %}
+            {
+              "name": "Product section"
+            }
+          {% endschema %}
+        END
+      )
+
+      assert_offenses("", offenses)
     end
 
     def test_accepts_valid_global_app_block_type


### PR DESCRIPTION
Part of https://github.com/Shopify/shopify/issues/304710

In order for theme sections to [support app blocks](https://shopify.dev/themes/migration#step-8-add-support-for-app-blocks-to-sections), sections need to define a block of type `@app`. This check makes sure that theme sections are not using the [deprecated](https://shopify.dev/changelog/removing-the-global-block-type-in-favour-of-the-app-block-type-in-theme-sections) `@global` global app block type in theme sections.

 :-1: Example of **incorrect** theme for this check:
 ```
 {% for block in section.blocks %}
   {% if block.type = "@global" %}
     {% render block %}
   {% endif %}
 {% endfor %}
 {% schema %}
 {
  "name": "Product section",
  "blocks": [{"type": "@global"}]
 }
 {% endschema %}
 ```

 :+1: Examples of **correct** code for this check:
 ```
 {% for block in section.blocks %}
   {% if block.type = "@app" %}
     {% render block %}
   {% endif %}
 {% endfor %}
 {% schema %}
 {
  "name": "Product section",
  "blocks": [{"type": "@app"}]
 }
 {% endschema %}
 ```

