### PR TITLE
Add new object drop: predictive_search

### DIFF
--- a/data/shopify_liquid/objects.yml
+++ b/data/shopify_liquid/objects.yml
@@ -54,6 +54,7 @@
 - part
 - policy
 - powered_by_link
+- predictive_search 
 - product
 - product_option
 - product_variant

--- a/test/shopify_liquid_test.rb
+++ b/test/shopify_liquid_test.rb
@@ -16,6 +16,6 @@ class ShopifyLiquidTest < Minitest::Test
   end
 
   def test_object_labels
-    assert_equal(82, ThemeCheck::ShopifyLiquid::Object.labels.size)
+    assert_equal(83, ThemeCheck::ShopifyLiquid::Object.labels.size)
   end
 end


### PR DESCRIPTION
### Purpose
Add the `predictive_search` drop to theme-check. 

fixes #409 

Last week, the new `predictive_search` drop was released and is documented [here](https://shopify.dev/api/liquid/objects/predictive-search).

### Approach 
I followed [this PR](https://github.com/Shopify/theme-check/pull/330) that added new objects to theme-check. 

- [x] Added `predictive_search` to `data/shopify_liquid/objects.yml`
- [x] Updated object count to 83 (`test/shopify_liquid_test.rb`)
   