### PR TITLE
Fix gnarly bug in Node and SpaceInsideBraces

### DIFF
--- a/lib/theme_check/checks/liquid_tag.rb
+++ b/lib/theme_check/checks/liquid_tag.rb
@@ -13,7 +13,7 @@ module ThemeCheck
     end
 
     def on_tag(node)
-      if !node.inside_liquid_tag?
+      if node.inside_liquid_tag?
         reset_consecutive_statements
       # Ignore comments
       elsif !node.comment?

--- a/lib/theme_check/checks/space_inside_braces.rb
+++ b/lib/theme_check/checks/space_inside_braces.rb
@@ -15,52 +15,57 @@ module ThemeCheck
       return if :assign == node.type_name
 
       outside_of_strings(node.markup) do |chunk, chunk_start|
-        chunk.scan(/([,:|]|==|<>|<=|>=|<|>|!=)  +/) do |_match|
+        chunk.scan(/([,:|]|==|<>|<=|>=|<|>|!=)(  +)/) do |_match|
           add_offense(
             "Too many spaces after '#{Regexp.last_match(1)}'",
             node: node,
-            markup: Regexp.last_match(0),
-            node_markup_offset: chunk_start + Regexp.last_match.begin(0)
+            markup: Regexp.last_match(2),
+            node_markup_offset: chunk_start + Regexp.last_match.begin(2)
           )
         end
         chunk.scan(/([,:|]|==|<>|<=|>=|<\b|>\b|!=)(\S|\z)/) do |_match|
           add_offense(
             "Space missing after '#{Regexp.last_match(1)}'",
             node: node,
-            markup: Regexp.last_match(0),
+            markup: Regexp.last_match(1),
             node_markup_offset: chunk_start + Regexp.last_match.begin(0),
           )
         end
-        chunk.scan(/  (\||==|<>|<=|>=|<|>|!=)+/) do |_match|
+        chunk.scan(/(  +)(\||==|<>|<=|>=|<|>|!=)+/) do |_match|
           add_offense(
-            "Too many spaces before '#{Regexp.last_match(1)}'",
+            "Too many spaces before '#{Regexp.last_match(2)}'",
             node: node,
-            markup: Regexp.last_match(0),
-            node_markup_offset: chunk_start + Regexp.last_match.begin(0)
+            markup: Regexp.last_match(1),
+            node_markup_offset: chunk_start + Regexp.last_match.begin(1)
           )
         end
         chunk.scan(/(\A|\S)(?<match>\||==|<>|<=|>=|<|\b>|!=)/) do |_match|
           add_offense(
             "Space missing before '#{Regexp.last_match(1)}'",
             node: node,
-            markup: Regexp.last_match(0),
-            node_markup_offset: chunk_start + Regexp.last_match.begin(0)
+            markup: Regexp.last_match(:match),
+            node_markup_offset: chunk_start + Regexp.last_match.begin(:match)
           )
         end
       end
     end
 
     def on_tag(node)
-      if node.inside_liquid_tag?
-        markup = if node.whitespace_trimmed?
-          "-%}"
-        else
-          "%}"
-        end
+      unless node.inside_liquid_tag?
         if node.markup[-1] != " " && node.markup[-1] != "\n"
-          add_offense("Space missing before '#{markup}'", node: node, markup: node.markup[-1] + markup)
+          add_offense(
+            "Space missing before '#{node.end_token}'",
+            node: node,
+            markup: node.markup[-1],
+            node_markup_offset: node.markup.size - 1,
+          )
         elsif node.markup =~ /(\n?)(  +)\z/m && Regexp.last_match(1) != "\n"
-          add_offense("Too many spaces before '#{markup}'", node: node, markup: Regexp.last_match(2) + markup)
+          add_offense(
+            "Too many spaces before '#{node.end_token}'",
+            node: node,
+            markup: Regexp.last_match(2),
+            node_markup_offset: node.markup.size - Regexp.last_match(2).size
+          )
         end
       end
       @ignore = true
@@ -73,22 +78,40 @@ module ThemeCheck
     def on_variable(node)
       return if @ignore || node.markup.empty?
       if node.markup[0] != " "
-        add_offense("Space missing after '{{'", node: node) do |corrector|
+        add_offense(
+          "Space missing after '#{node.start_token}'",
+          node: node,
+          markup: node.markup[0]
+        ) do |corrector|
           corrector.insert_before(node, " ")
         end
       end
       if node.markup[-1] != " " && node.markup[-1] != "\n"
-        add_offense("Space missing before '}}'", node: node) do |corrector|
+        add_offense(
+          "Space missing before '#{node.end_token}'",
+          node: node,
+          markup: node.markup[-1],
+          node_markup_offset: node.markup.size - 1,
+        ) do |corrector|
           corrector.insert_after(node, " ")
         end
       end
-      if node.markup[0] == " " && node.markup[1] == " "
-        add_offense("Too many spaces after '{{'", node: node) do |corrector|
+      if node.markup =~ /\A(  +)/m
+        add_offense(
+          "Too many spaces after '#{node.start_token}'",
+          node: node,
+          markup: Regexp.last_match(1),
+        ) do |corrector|
           corrector.replace(node, " #{node.markup.lstrip}")
         end
       end
-      if node.markup[-1] == " " && node.markup[-2] == " "
-        add_offense("Too many spaces before '}}'", node: node) do |corrector|
+      if node.markup =~ /(\n?)(  +)\z/m && Regexp.last_match(1) != "\n"
+        add_offense(
+          "Too many spaces before '#{node.end_token}'",
+          node: node,
+          markup: Regexp.last_match(2),
+          node_markup_offset: node.markup.size - Regexp.last_match(2).size
+        ) do |corrector|
           corrector.replace(node, "#{node.markup.rstrip} ")
         end
       end

--- a/lib/theme_check/node.rb
+++ b/lib/theme_check/node.rb
@@ -10,12 +10,14 @@ module ThemeCheck
       @value = value
       @parent = parent
       @template = template
+      @tag_markup = nil
+      @line_number_offset = 0
     end
 
     # The original source code of the node. Doesn't contain wrapping braces.
     def markup
       if tag?
-        @value.raw
+        tag_markup
       elsif @value.instance_variable_defined?(:@markup)
         @value.instance_variable_get(:@markup)
       end
@@ -64,6 +66,10 @@ module ThemeCheck
       @value.is_a?(Liquid::Tag)
     end
 
+    def variable?
+      @value.is_a?(Liquid::Variable)
+    end
+
     # A {% comment %} block node?
     def comment?
       @value.is_a?(Liquid::Comment)
@@ -92,7 +98,12 @@ module ThemeCheck
 
     # Most nodes have a line number, but it's not guaranteed.
     def line_number
-      @value.line_number if @value.respond_to?(:line_number)
+      if tag? && @value.respond_to?(:line_number)
+        markup # initialize the line_number_offset
+        @value.line_number - @line_number_offset
+      elsif @value.respond_to?(:line_number)
+        @value.line_number
+      end
     end
 
     # The `:under_score_name` of this type of node. Used to dispatch to the `on_<type_name>`
@@ -101,19 +112,45 @@ module ThemeCheck
       @type_name ||= StringHelpers.underscore(StringHelpers.demodulize(@value.class.name)).to_sym
     end
 
+    def source
+      template&.source
+    end
+
+    WHITESPACE = /\s/
+
     # Is this node inside a `{% liquid ... %}` block?
     def inside_liquid_tag?
-      if line_number
-        template.excerpt(line_number).start_with?("{%")
+      # What we're doing here is starting at the start of the tag and
+      # backtrack on all the whitespace until we land on something. If
+      # that something is {% or %-, then we can safely assume that
+      # we're inside a full tag and not a liquid tag.
+      @inside_liquid_tag ||= if tag? && line_number && source
+        i = 1
+        i += 1 while source[start_index - i] =~ WHITESPACE && i < start_index
+        first_two_backtracked_characters = source[(start_index - i - 1)..(start_index - i)]
+        first_two_backtracked_characters != "{%" && first_two_backtracked_characters != "%-"
       else
         false
       end
     end
 
-    # Is this node inside a `{%- ... -%}`
-    def whitespace_trimmed?
-      if line_number
-        template.excerpt(line_number).start_with?("{%-")
+    # Is this node inside a tag or variable that starts by removing whitespace. i.e. {%- or {{-
+    def whitespace_trimmed_start?
+      @whitespace_trimmed_start ||= if line_number && source
+        i = 1
+        i += 1 while source[start_index - i] =~ WHITESPACE && i < start_index
+        source[start_index - i] == "-"
+      else
+        false
+      end
+    end
+
+    # Is this node inside a tag or variable ends starts by removing whitespace. i.e. -%} or -}}
+    def whitespace_trimmed_end?
+      @whitespace_trimmed_end ||= if line_number && source
+        i = 0
+        i += 1 while source[end_index + i] =~ WHITESPACE && i < source.size
+        source[end_index + i] == "-"
       else
         false
       end
@@ -132,12 +169,87 @@ module ThemeCheck
       )
     end
 
+    def start_token
+      return "" if inside_liquid_tag?
+      output = ""
+      output += "{{" if variable?
+      output += "{%" if tag?
+      output += "-" if whitespace_trimmed_start?
+      output
+    end
+
+    def end_token
+      return "" if inside_liquid_tag?
+      output = ""
+      output += "-" if whitespace_trimmed_end?
+      output += "}}" if variable?
+      output += "%}" if tag?
+      output
+    end
+
     def start_index
       position.start_index
     end
 
     def end_index
       position.end_index
+    end
+
+    private
+
+    # Here we're hacking around a glorious bug in Liquid that makes it so the
+    # line_number and markup of a tag is wrong if there's whitespace
+    # between the tag_name and the markup of the tag.
+    #
+    # {%
+    #   render
+    #   'foo'
+    # %}
+    #
+    # Returns a raw value of "render 'foo'\n".
+    # The "\n  " between render and 'foo' got replaced by a single space.
+    #
+    # And the line number is the one of 'foo'\n%}. Yay!
+    #
+    # This breaks any kind of position logic we have since that string
+    # does not exist in the template.
+    def tag_markup
+      return @value.raw if @value.instance_variable_get('@markup').empty?
+      return @tag_markup if @tag_markup
+
+      l = 1
+      scanner = StringScanner.new(source)
+      scanner.scan_until(/\n/) while l < @value.line_number && (l += 1)
+      start = scanner.charpos
+
+      tag_markup = @value.instance_variable_get('@markup')
+
+      # See https://github.com/Shopify/theme-check/pull/423/files#r701936559 for a detailed explanation
+      # of why we're doing the check below.
+      #
+      # TL;DR it's because line_numbers are not enough to accurately
+      # determine the position of the raw markup and because that
+      # markup could be present on the same line outside of a Tag. e.g.
+      #
+      # uhoh {% if uhoh %}
+      if (match = /#{@value.tag_name} +#{Regexp.escape(tag_markup)}/.match(source, start))
+        return @tag_markup = match[0]
+      end
+
+      # find the markup
+      markup_start = source.index(tag_markup, start)
+      markup_end = markup_start + tag_markup.size
+
+      # go back until you find the tag_name
+      tag_start = markup_start
+      tag_start -= 1 while source[tag_start - 1] =~ WHITESPACE
+      tag_start -= @value.tag_name.size
+
+      # keep track of the error in line_number
+      @line_number_offset = source[tag_start...markup_start].count("\n")
+
+      # return the real raw content
+      @tag_markup = source[tag_start...markup_end]
     end
   end
 end

--- a/lib/theme_check/node.rb
+++ b/lib/theme_check/node.rb
@@ -136,7 +136,7 @@ module ThemeCheck
 
     # Is this node inside a tag or variable that starts by removing whitespace. i.e. {%- or {{-
     def whitespace_trimmed_start?
-      @whitespace_trimmed_start ||= if line_number && source
+      @whitespace_trimmed_start ||= if line_number && source && !inside_liquid_tag?
         i = 1
         i += 1 while source[start_index - i] =~ WHITESPACE && i < start_index
         source[start_index - i] == "-"
@@ -147,7 +147,7 @@ module ThemeCheck
 
     # Is this node inside a tag or variable ends starts by removing whitespace. i.e. -%} or -}}
     def whitespace_trimmed_end?
-      @whitespace_trimmed_end ||= if line_number && source
+      @whitespace_trimmed_end ||= if line_number && source && !inside_liquid_tag?
         i = 0
         i += 1 while source[end_index + i] =~ WHITESPACE && i < source.size
         source[end_index + i] == "-"

--- a/lib/theme_check/position_helper.rb
+++ b/lib/theme_check/position_helper.rb
@@ -19,9 +19,10 @@ module ThemeCheck
       return [0, 0] unless content.is_a?(String) && !content.empty?
       return [0, 0] unless index.is_a?(Integer)
       safe_index = bounded(0, index, content.size - 1)
-      lines = content[0..safe_index].lines
-      row = lines.size - 1
-      col = lines.last.size - 1
+      content_up_to_index = content[0...safe_index]
+      row = content_up_to_index.count("\n")
+      col = 0
+      col += 1 while (safe_index -= 1) && safe_index >= 0 && content[safe_index] != "\n"
       [row, col]
     end
 

--- a/lib/theme_check/position_helper.rb
+++ b/lib/theme_check/position_helper.rb
@@ -7,17 +7,12 @@ module ThemeCheck
       return 0 unless content.is_a?(String) && !content.empty?
       return 0 unless row.is_a?(Integer) && col.is_a?(Integer)
       i = 0
-      result = 0
-      safe_row = bounded(0, row, content.lines.size - 1)
-      lines = content.lines
-      line_size = lines[i].size
-      while i < safe_row
-        result += line_size
-        i += 1
-        line_size = lines[i].size
-      end
-      result += bounded(0, col, line_size - 1)
-      result
+      safe_row = bounded(0, row, content.count("\n"))
+      scanner = StringScanner.new(content)
+      scanner.scan_until(/\n/) while i < safe_row && (i += 1)
+      result = scanner.charpos || 0
+      scanner.scan_until(/\n|\z/)
+      bounded(result, result + col, scanner.pre_match.size)
     end
 
     def from_index_to_row_column(content, index)
@@ -31,7 +26,9 @@ module ThemeCheck
     end
 
     def bounded(a, x, b)
-      [a, [x, b].min].max
+      return a if x < a
+      return b if x > b
+      x
     end
   end
 end

--- a/test/checks/space_inside_braces_test.rb
+++ b/test/checks/space_inside_braces_test.rb
@@ -7,14 +7,24 @@ class SpaceInsideBracesTest < Minitest::Test
       ThemeCheck::SpaceInsideBraces.new,
       "templates/index.liquid" => <<~END,
         {% assign x = 1%}
+        {% assign x = 2-%}
+        {%- assign x = 3%}
+        {%- assign x = 4-%}
         {{ x}}
+        {{ x-}}
         {{x }}
+        {{-x }}
       END
     )
     assert_offenses(<<~END, offenses)
       Space missing before '%}' at templates/index.liquid:1
-      Space missing before '}}' at templates/index.liquid:2
-      Space missing after '{{' at templates/index.liquid:3
+      Space missing before '-%}' at templates/index.liquid:2
+      Space missing before '%}' at templates/index.liquid:3
+      Space missing before '-%}' at templates/index.liquid:4
+      Space missing before '}}' at templates/index.liquid:5
+      Space missing before '-}}' at templates/index.liquid:6
+      Space missing after '{{' at templates/index.liquid:7
+      Space missing after '{{-' at templates/index.liquid:8
     END
   end
 
@@ -23,14 +33,20 @@ class SpaceInsideBracesTest < Minitest::Test
       ThemeCheck::SpaceInsideBraces.new,
       "templates/index.liquid" => <<~END,
         {{  x }}
+        {{-  x }}
         {% assign x = 1  %}
+        {% assign x = 1  -%}
         {{ x  }}
+        {{ x  -}}
       END
     )
     assert_offenses(<<~END, offenses)
       Too many spaces after '{{' at templates/index.liquid:1
-      Too many spaces before '%}' at templates/index.liquid:2
-      Too many spaces before '}}' at templates/index.liquid:3
+      Too many spaces after '{{-' at templates/index.liquid:2
+      Too many spaces before '%}' at templates/index.liquid:3
+      Too many spaces before '-%}' at templates/index.liquid:4
+      Too many spaces before '}}' at templates/index.liquid:5
+      Too many spaces before '-}}' at templates/index.liquid:6
     END
   end
 
@@ -303,18 +319,79 @@ class SpaceInsideBracesTest < Minitest::Test
     assert_offenses('', offenses)
   end
 
-  def test_reports_properly
+  def test_reports_correct_location_range
+    [
+      {
+        #          The two lines below are there to help identify the index
+        #          0000000000111111111122222222223333333333
+        #          0123456789012345678901234567890123456789
+        template: "{{all_products }}",
+        expected: "Space missing after '{{' at templates/index.liquid:2:3",
+      },
+      {
+        template: "{{   all_products }}",
+        expected: "Too many spaces after '{{' at templates/index.liquid:2:5",
+      },
+      {
+        template: "{{ all_products}}",
+        expected: "Space missing before '}}' at templates/index.liquid:14:15",
+      },
+      {
+        template: "{{ all_products   }}",
+        expected: "Too many spaces before '}}' at templates/index.liquid:15:18",
+      },
+      {
+        template: "{{ 'a' | replace: ', ',',' | split: ',' }}",
+        expected: "Space missing after ',' at templates/index.liquid:22:23",
+      },
+      {
+        template: "{% assign x = n-%}",
+        expected: "Space missing before '-%}' at templates/index.liquid:14:15",
+      },
+      {
+        template: "{% assign x = n  -%}",
+        expected: "Too many spaces before '-%}' at templates/index.liquid:15:17",
+      },
+      {
+        template: '{%- if x !=  "x" -%}{%- endif -%}',
+        expected: "Too many spaces after '!=' at templates/index.liquid:11:13",
+      },
+      {
+        template: '{%- if x  != "x" -%}{%- endif -%}',
+        expected: "Too many spaces before '!=' at templates/index.liquid:8:10",
+      },
+      {
+        template: '{%- if x !="x" -%}{%- endif -%}',
+        expected: "Space missing after '!=' at templates/index.liquid:9:11",
+      },
+      {
+        template: '{%- if x!= "x" -%}{%- endif -%}',
+        expected: "Space missing before '!=' at templates/index.liquid:8:10",
+      },
+    ].each do |test_desc|
+      offenses = analyze_theme(
+        ThemeCheck::SpaceInsideBraces.new,
+        "templates/index.liquid" => test_desc[:template]
+      )
+      assert_offenses_with_range(
+        test_desc[:expected],
+        offenses
+      )
+    end
+  end
+
+  def test_reports_properly_at_end_tag
     offenses = analyze_theme(
       ThemeCheck::SpaceInsideBraces.new,
       "templates/index.liquid" => <<~END,
-        {{ 'a' | replace: ', ',',' | split: ',' }}
-        0000000000111111111122222222223333333333
-        0123456789012345678901234567890123456789
+        {% assign x = n-%}
+        00000000001111111
+        01234567890123456
         The two lines above are there to help identify the index
       END
     )
     assert_offenses_with_range(
-      "Space missing after ',' at templates/index.liquid:22:23",
+      "Space missing before '-%}' at templates/index.liquid:14:15",
       offenses
     )
   end

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -74,8 +74,20 @@ module ThemeCheck
         pre text{%
           assign x = 6
         %}
+        {% liquid
+          assign x = 7
+        %}
+        {%- liquid
+          assign x = 8
+        -%}
         {{- yes }}
         {{ no }}
+        {{-
+          foo
+        }}
+        {{
+          bar
+        -}}
       END
       node = find(root) { |n| n.markup =~ /assign x = 1/ }
       assert(node.whitespace_trimmed_start?)
@@ -89,9 +101,18 @@ module ThemeCheck
       assert(node.whitespace_trimmed_start?)
       node = find(root) { |n| n.markup =~ /assign x = 6/ }
       refute(node.whitespace_trimmed_start?)
+      # doesn't make sense in liquid tags
+      node = find(root) { |n| n.markup =~ /assign x = 7/ }
+      refute(node.whitespace_trimmed_start?)
+      node = find(root) { |n| n.markup =~ /assign x = 8/ }
+      refute(node.whitespace_trimmed_start?)
       node = find(root) { |n| n.markup =~ /yes/ }
       assert(node.whitespace_trimmed_start?)
       node = find(root) { |n| n.markup =~ /no/ }
+      refute(node.whitespace_trimmed_start?)
+      node = find(root) { |n| n.markup =~ /foo/ }
+      assert(node.whitespace_trimmed_start?)
+      node = find(root) { |n| n.markup =~ /bar/ }
       refute(node.whitespace_trimmed_start?)
     end
 
@@ -111,8 +132,20 @@ module ThemeCheck
         pre text{%
           assign x = 6
         %}
+        {% liquid
+          assign x = 7
+        %}
+        {%- liquid
+          assign x = 8
+        -%}
         {{ yes -}}
         {{ no }}
+        {{-
+          foo
+        }}
+        {{
+          bar
+        -}}
       END
       node = find(root) { |n| n.markup =~ /assign x = 1/ }
       assert(node.whitespace_trimmed_end?)
@@ -126,10 +159,19 @@ module ThemeCheck
       assert(node.whitespace_trimmed_end?)
       node = find(root) { |n| n.markup =~ /assign x = 6/ }
       refute(node.whitespace_trimmed_end?)
+      # doesn't make sense in liquid tags
+      node = find(root) { |n| n.markup =~ /assign x = 7/ }
+      refute(node.whitespace_trimmed_end?)
+      node = find(root) { |n| n.markup =~ /assign x = 8/ }
+      refute(node.whitespace_trimmed_end?)
       node = find(root) { |n| n.markup =~ /yes/ }
       assert(node.whitespace_trimmed_end?)
       node = find(root) { |n| n.markup =~ /no/ }
       refute(node.whitespace_trimmed_end?)
+      node = find(root) { |n| n.markup =~ /foo/ }
+      refute(node.whitespace_trimmed_end?)
+      node = find(root) { |n| n.markup =~ /bar/ }
+      assert(node.whitespace_trimmed_end?)
     end
 
     private

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module ThemeCheck
+  class NodeTest < Minitest::Test
+    def test_markup
+      root = root_node(<<~END)
+        <ul class="{% if true %}list{% endif %}>
+          <li>{% liquid
+            assign x = 1
+            echo x
+          %}</li>
+          {%
+            render
+            'foo'
+          %}
+          {% comment   %}hi{% endcomment %}
+        </ul>
+      END
+      node = find(root) { |n| n.type_name == :if }
+      assert_equal("if true ", node.markup)
+      node = find(root) { |n| n.type_name == :assign }
+      assert_equal("assign x = 1", node.markup)
+      node = find(root) { |n| n.type_name == :echo }
+      assert_equal("echo x", node.markup)
+      node = find(root) { |n| n.type_name == :render }
+      assert_equal("render\n    'foo'\n  ", node.markup)
+      # Note, the following also doesn't return content as expected.
+      # We're getting "comment " back
+      # node = find(root) { |n| n.type_name == :comment }
+      # assert_equal("comment   ", node.markup)
+    end
+
+    def test_inside_liquid_tag?
+      root = root_node(<<~END)
+        <ul class="{% if true %}list{% endif %}>
+          <li>{% liquid
+            assign x = 1
+            echo x
+          %}</li>
+          {%
+            render
+            'foo'
+          %}
+          {% comment %}hi{% endcomment %}
+          # weird implementation edge case (markup is present before tag on the same line)
+          a {% if a %}{% endif %}
+      END
+      node = find(root) { |n| n.markup == "if true " }
+      refute(node.inside_liquid_tag?)
+      node = find(root) { |n| n.type_name == :assign }
+      assert(node.inside_liquid_tag?)
+      node = find(root) { |n| n.type_name == :echo }
+      assert(node.inside_liquid_tag?)
+      node = find(root) { |n| n.type_name == :render }
+      refute(node.inside_liquid_tag?)
+      node = find(root) { |n| n.markup =~ /if a/ }
+      refute(node.inside_liquid_tag?)
+    end
+
+    def test_whitespace_trimmed_start?
+      root = root_node(<<~END)
+        {%- assign x = 1 %}
+        {% assign x = 2 %}
+        {%-
+          assign x = 3
+        %}
+        {%
+          assign x = 4
+        %}
+        pre text{%-
+          assign x = 5
+        %}
+        pre text{%
+          assign x = 6
+        %}
+        {{- yes }}
+        {{ no }}
+      END
+      node = find(root) { |n| n.markup =~ /assign x = 1/ }
+      assert(node.whitespace_trimmed_start?)
+      node = find(root) { |n| n.markup =~ /assign x = 2/ }
+      refute(node.whitespace_trimmed_start?)
+      node = find(root) { |n| n.markup =~ /assign x = 3/ }
+      assert(node.whitespace_trimmed_start?)
+      node = find(root) { |n| n.markup =~ /assign x = 4/ }
+      refute(node.whitespace_trimmed_start?)
+      node = find(root) { |n| n.markup =~ /assign x = 5/ }
+      assert(node.whitespace_trimmed_start?)
+      node = find(root) { |n| n.markup =~ /assign x = 6/ }
+      refute(node.whitespace_trimmed_start?)
+      node = find(root) { |n| n.markup =~ /yes/ }
+      assert(node.whitespace_trimmed_start?)
+      node = find(root) { |n| n.markup =~ /no/ }
+      refute(node.whitespace_trimmed_start?)
+    end
+
+    def test_whitespace_trimmed_end?
+      root = root_node(<<~END)
+        {% assign x = 1 -%}
+        {% assign x = 2 %}
+        {%
+          assign x = 3
+        -%}
+        {%
+          assign x = 4
+        %}
+        pre text{%
+          assign x = 5
+        -%}
+        pre text{%
+          assign x = 6
+        %}
+        {{ yes -}}
+        {{ no }}
+      END
+      node = find(root) { |n| n.markup =~ /assign x = 1/ }
+      assert(node.whitespace_trimmed_end?)
+      node = find(root) { |n| n.markup =~ /assign x = 2/ }
+      refute(node.whitespace_trimmed_end?)
+      node = find(root) { |n| n.markup =~ /assign x = 3/ }
+      assert(node.whitespace_trimmed_end?)
+      node = find(root) { |n| n.markup =~ /assign x = 4/ }
+      refute(node.whitespace_trimmed_end?)
+      node = find(root) { |n| n.markup =~ /assign x = 5/ }
+      assert(node.whitespace_trimmed_end?)
+      node = find(root) { |n| n.markup =~ /assign x = 6/ }
+      refute(node.whitespace_trimmed_end?)
+      node = find(root) { |n| n.markup =~ /yes/ }
+      assert(node.whitespace_trimmed_end?)
+      node = find(root) { |n| n.markup =~ /no/ }
+      refute(node.whitespace_trimmed_end?)
+    end
+
+    private
+
+    def root_node(code)
+      template = parse_liquid(code)
+      Node.new(template.root, nil, template)
+    end
+
+    def find(node, &block)
+      return node if yield node
+      return nil if node.children.nil? || node.children.empty?
+      node.children.find { |n| find(n, &block) }
+    end
+  end
+end

--- a/test/position_helper_test.rb
+++ b/test/position_helper_test.rb
@@ -6,6 +6,17 @@ module ThemeCheck
     class PositionHelperTest < Minitest::Test
       include PositionHelper
 
+      def content
+        <<~LIQUID
+          abcdefg
+          hijklmnop
+          qrs
+          tuv
+          wx
+          yz
+        LIQUID
+      end
+
       def test_convert_from_row_column_to_index
         assert_equal(content.index('a'), from_row_column_to_index(content, 0, 0))
         assert_equal(content.index('e'), from_row_column_to_index(content, 0, 4))
@@ -46,19 +57,6 @@ module ThemeCheck
         assert_equal(content.index("\n"), from_row_column_to_index(content, 0, 20))
         assert_equal(content.index('h'), from_row_column_to_index(content, 1, -1))
         assert_equal(content.index("\n", content.index("\n") + 1), from_row_column_to_index(content, 1, 20))
-      end
-
-      private
-
-      def content
-        <<~LIQUID
-          abcdefg
-          hijklmnop
-          qrs
-          tuv
-          wx
-          yz
-        LIQUID
       end
     end
   end

--- a/test/position_helper_test.rb
+++ b/test/position_helper_test.rb
@@ -24,6 +24,7 @@ module ThemeCheck
         assert_equal(content.index('m'), from_row_column_to_index(content, 1, 5))
         assert_equal(content.index('r'), from_row_column_to_index(content, 2, 1))
         assert_equal(content.index('z'), from_row_column_to_index(content, 5, 1))
+        assert_equal(content.index("\n"), from_row_column_to_index(content, 0, 7))
       end
 
       def test_convert_index_to_row_column
@@ -33,6 +34,7 @@ module ThemeCheck
         assert_equal([1, 5], from_index_to_row_column(content, content.index('m')))
         assert_equal([2, 1], from_index_to_row_column(content, content.index('r')))
         assert_equal([5, 1], from_index_to_row_column(content, content.index('z')))
+        assert_equal([0, 7], from_index_to_row_column(content, content.index("\n")))
       end
 
       def test_handles_empty_content_gracefully

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -116,7 +116,7 @@ module Minitest
       assert_equal(
         output.chomp,
         offenses
-          .sort_by(&:location_range)
+          .sort_by { |o| [o.location_range, o.message].join(' ') }
           .map(&:to_s_range)
           .join("\n")
       )


### PR DESCRIPTION
Fixes #420

This fixes a LOT of bugs actually! This bug was like finding a little crack in a wall and then finding you have termites.

1. This is Liquid's `raw` output for the following tag:

   ```
   {%
     render
     'file'
   %}
   # expected
   => "render\n  'file'\n"
   # actual
   => "render 'file'\n"
   ```

   As you can see, not only do we _not_ have the whitespace all the way till "render", we also don't have the whitespace between render and 'file'. This breaks all Position calculations since the needle does not exist in the source.

2.  The implementation of `whitespace_trimmed?` didn't account for tags starting in the middle of a line. Or for tags starting on a different line

    ```
    <ul class="{%- if true -%}oh no{% endif %}">
    => not whitespace trimmed!
    {%-
      render 'oh no'
    -%}
    => not whitespace trimmed!
    ```

3.  The implementation of `whitespace_trimmed?` assumed that it was trimmed in pairs (start and end) when it's possible to do it independently.

    ```
    {% assign true -%}
    => not whitespace trimmed!
    ```

4.  Similarly a lot of our logic for space before/after tokens was wrong inside SpaceInsideBraces

4.  Our implementation of `inside_liquid_tag?` was flipped. The tests were wrong and the implementation was too!