### PR TITLE
Fix undefined method [] of nil in replace_placeholders

### DIFF
--- a/lib/theme_check/html_node.rb
+++ b/lib/theme_check/html_node.rb
@@ -67,10 +67,10 @@ module ThemeCheck
     private
 
     def replace_placeholders(string)
-      # Replace all {%#{i}####%} with the actual content.
-      string.gsub(LIQUID_TAG) do |match|
-        key = /\d+/.match(match)[0]
-        @placeholder_values[key.to_i]
+      # Replace all ≬{i}####≬ with the actual content.
+      string.gsub(HTML_LIQUID_PLACEHOLDER) do |match|
+        key = /[0-9a-z]+/.match(match)[0]
+        @placeholder_values[key.to_i(36)]
       end
     end
   end

--- a/lib/theme_check/html_visitor.rb
+++ b/lib/theme_check/html_visitor.rb
@@ -24,14 +24,22 @@ module ThemeCheck
     def parse(template)
       parseable_source = +template.source.clone
 
-      # Replace all liquid tags with {%#{i}######%} to prevent the HTML
+      # Replace all liquid tags with ≬{i}######≬ to prevent the HTML
       # parser from freaking out. We transparently replace those placeholders in
       # HtmlNode.
+      #
+      # We're using base36 to prevent index bleeding on 36^2 empty tags.
+      # `{{}}` -> `≬#{i}≬` would properly be transformed for 1296 tags in a single file.
+      # This _seems_ like it's enough.
+      #
+      # The base10 alternative would have overflowed at 100 (`{{}}` -> `≬100≬`) which seemed more likely.
+      #
+      # Didn't go with base64 because of the `=` character that would have messed with HTML parsing.
       matches(parseable_source, LIQUID_TAG_OR_VARIABLE).each do |m|
         value = m[0]
         @placeholder_values.push(value)
-        key = (@placeholder_values.size - 1).to_s
-        parseable_source[m.begin(0)...m.end(0)] = "{%#{key.ljust(m.end(0) - m.begin(0) - 4, '#')}%}"
+        key = (@placeholder_values.size - 1).to_s(36)
+        parseable_source[m.begin(0)...m.end(0)] = "≬#{key.ljust(m.end(0) - m.begin(0) - 2, '#')}≬"
       end
 
       Nokogiri::HTML5.fragment(parseable_source, max_tree_depth: 400, max_attributes: 400)

--- a/lib/theme_check/html_visitor.rb
+++ b/lib/theme_check/html_visitor.rb
@@ -24,19 +24,20 @@ module ThemeCheck
       placeholder_values = []
       parseable_source = +template.source.clone
 
-      # Replace all liquid tags with ≬{i}######≬ to prevent the HTML
+      # Replace all non-empty liquid tags with ≬{i}######≬ to prevent the HTML
       # parser from freaking out. We transparently replace those placeholders in
       # HtmlNode.
       #
-      # We're using base36 to prevent index bleeding on 36^2 empty tags.
-      # `{{}}` -> `≬#{i}≬` would properly be transformed for 1296 tags in a single file.
-      # This _seems_ like it's enough.
+      # We're using base36 to prevent index bleeding on 36^3 tags.
+      # `{{x}}` -> `≬#{i}≬` would properly be transformed for 46656 tags in a single file.
+      # Should be enough.
       #
-      # The base10 alternative would have overflowed at 100 (`{{}}` -> `≬100≬`) which seemed more likely.
+      # The base10 alternative would have overflowed at 1000 (`{{x}}` -> `≬1000≬`) which seemed more likely.
       #
       # Didn't go with base64 because of the `=` character that would have messed with HTML parsing.
       matches(parseable_source, LIQUID_TAG_OR_VARIABLE).each do |m|
         value = m[0]
+        next unless value.size > 4 # skip empty tags/variables {%%} and {{}}
         placeholder_values.push(value)
         key = (placeholder_values.size - 1).to_s(36)
         parseable_source[m.begin(0)...m.end(0)] = "≬#{key.ljust(m.end(0) - m.begin(0) - 2, '#')}≬"

--- a/lib/theme_check/regex_helpers.rb
+++ b/lib/theme_check/regex_helpers.rb
@@ -5,6 +5,7 @@ module ThemeCheck
     LIQUID_TAG = /#{Liquid::TagStart}.*?#{Liquid::TagEnd}/om
     LIQUID_VARIABLE = /#{Liquid::VariableStart}.*?#{Liquid::VariableEnd}/om
     LIQUID_TAG_OR_VARIABLE = /#{LIQUID_TAG}|#{LIQUID_VARIABLE}/om
+    HTML_LIQUID_PLACEHOLDER = /≬[0-9a-z]+#*≬/m
     START_OR_END_QUOTE = /(^['"])|(['"]$)/
 
     def matches(s, re)

--- a/test/html_visitor_test.rb
+++ b/test/html_visitor_test.rb
@@ -157,6 +157,59 @@ module ThemeCheck
       end
     end
 
+    def test_weird_edge_cases_shouldnt_throw
+      @attribute_checker = HTMLAttributeIntegrityMockCheck.new
+      @visitor = HtmlVisitor.new(Checks.new([@attribute_checker]))
+      template = parse_liquid(<<~END)
+        <html>
+          <b x={% %} y="{{ }}" z="{{}}" a="{{}}" b="{{}}" c="{{}}" d="{{}}"></b>
+          <b x={% %} y="{{ }}" z="{{}}" a="{{}}" b="{{}}" c="{{}}" d="{{}}"></b>
+          <b x={% %} y="{{ }}" z="{{}}" a="{{}}" b="{{}}" c="{{}}" d="{{}}"></b>
+        </html>
+      END
+      @visitor.visit_template(template)
+      [
+        {
+          name: "b",
+          attributes: {
+            "a" => "{{}}",
+            "b" => "{{}}",
+            "c" => "{{}}",
+            "d" => "{{}}",
+            "x" => "{% %}",
+            "y" => "{{ }}",
+            "z" => "{{}}",
+          },
+        },
+        {
+          name: "b",
+          attributes: {
+            "a" => "{{}}",
+            "b" => "{{}}",
+            "c" => "{{}}",
+            "d" => "{{}}",
+            "x" => "{% %}",
+            "y" => "{{ }}",
+            "z" => "{{}}",
+          },
+        },
+        {
+          name: "b",
+          attributes: {
+            "a" => "{{}}",
+            "b" => "{{}}",
+            "c" => "{{}}",
+            "d" => "{{}}",
+            "x" => "{% %}",
+            "y" => "{{ }}",
+            "z" => "{{}}",
+          },
+        },
+      ].each_with_index do |element, i|
+        assert_equal(element, @attribute_checker.elements[i], "i #{i}")
+      end
+    end
+
     class HTMLAttributeIntegrityMockCheck < Check
       attr_reader :elements
 


### PR DESCRIPTION
Fixes #441

<s>
Couldn't figure out why replace_placeholder was finding liquid tags that
didn't contain an index but this way I'm sure that both of the following
will be true:

1. There definitely _is_ an index. (because the regex guarantees it)
2. It would take 1296 liquid tags/variables for an overflow to be
   possible on an empty tag.
</s>

See comments below. Figured it out.