### PR TITLE
Disable ConvertIncludeToRender corrector

### DIFF
--- a/lib/theme_check/checks/convert_include_to_render.rb
+++ b/lib/theme_check/checks/convert_include_to_render.rb
@@ -8,7 +8,8 @@ module ThemeCheck
 
     def on_include(node)
       add_offense("`include` is deprecated - convert it to `render`", node: node) do |corrector|
-        corrector.replace(node, "render \'#{node.value.template_name_expr}\' ")
+        # We need to fix #445 and pass the variables from the context or don't replace at all.
+        # corrector.replace(node, "render \'#{node.value.template_name_expr}\' ")
       end
     end
   end

--- a/test/checks/convert_include_to_render_test.rb
+++ b/test/checks/convert_include_to_render_test.rb
@@ -25,17 +25,28 @@ class ConvertIncludeToRenderTest < Minitest::Test
   end
 
   def test_corrects_include
-    expected_sources = {
-      "templates/index.liquid" => <<~END,
-        {% render 'templates/foo.liquid' %}
-      END
-    }
+    skip
     sources = fix_theme(
       ThemeCheck::ConvertIncludeToRender.new,
       "templates/index.liquid" => <<~END,
-        {% include 'templates/foo.liquid' %}
+        {% include 'foo.liquid' %}
+        {% assign greeting = "hello world" %}
+        {% include 'greeting.liquid' %}
+      END
+      "snippets/greeting.liquid" => <<~END,
+        {{ greeting }}
       END
     )
+    expected_sources = {
+      "templates/index.liquid" => <<~END,
+        {% render 'foo.liquid' %}
+        {% assign greeting = "hello world" %}
+        {% render 'greeting.liquid', greeting: greeting %}
+      END
+      "snippets/greeting.liquid" => <<~END,
+        {{ greeting }}
+      END
+    }
     sources.each do |path, source|
       assert_equal(expected_sources[path], source)
     end


### PR DESCRIPTION
See #445 for details. The corrector shouldn't break your site.
