### PR TITLE
Fix `Undefined method `-' for nil:NilClass` in Node

### DIFF
--- a/lib/theme_check/checks.rb
+++ b/lib/theme_check/checks.rb
@@ -50,6 +50,7 @@ module ThemeCheck
       template = node.respond_to?(:template) ? node.template.relative_path : "?"
       markup = node.respond_to?(:markup) ? node.markup : ""
       node_class = node.respond_to?(:value) ? node.value.class : "?"
+      line_number = node.respond_to?(:line_number) ? node.line_number : "?"
 
       ThemeCheck.bug(<<~EOS)
         Exception while running `#{check.code_name}##{method}`:
@@ -64,6 +65,7 @@ module ThemeCheck
         ```
         #{markup}
         ```
+        Line number: #{line_number}
         Check options: `#{check.options.pretty_inspect}`
       EOS
     end

--- a/lib/theme_check/node.rb
+++ b/lib/theme_check/node.rb
@@ -209,7 +209,7 @@ module ThemeCheck
     # This breaks any kind of position logic we have since that string
     # does not exist in the template.
     def tag_markup
-      return @value.raw if @value.instance_variable_get('@markup').empty?
+      return @value.tag_name if @value.instance_variable_get('@markup').empty?
       return @tag_markup if @tag_markup
 
       l = 1


### PR DESCRIPTION
Turns out that `{%comment%}`.raw is `"comment "`. This led the Position
class to be unable to find `"comment "` in the source which led to
start_index being undefined and causing this nil error.

You're guaranteed to find `{%comment%}`.tag_name so we should be good to go.

Fixes #452