### PR TITLE
SpaceInsideBraces fixup for tags without arguments

### DIFF
--- a/lib/theme_check/position.rb
+++ b/lib/theme_check/position.rb
@@ -104,7 +104,7 @@ module ThemeCheck
     end
 
     def can_find_needle?
-      !!contents.index(@needle)
+      !!contents.index(@needle, start_offset)
     end
 
     def entire_line_needle

--- a/test/checks/space_inside_braces_test.rb
+++ b/test/checks/space_inside_braces_test.rb
@@ -14,6 +14,8 @@ class SpaceInsideBracesTest < Minitest::Test
         {{ x-}}
         {{x }}
         {{-x }}
+        {%comment%}
+        {% endcomment %}
       END
     )
     assert_offenses(<<~END, offenses)
@@ -25,7 +27,23 @@ class SpaceInsideBracesTest < Minitest::Test
       Space missing before '-}}' at templates/index.liquid:6
       Space missing after '{{' at templates/index.liquid:7
       Space missing after '{{-' at templates/index.liquid:8
+      Space missing before '%}' at templates/index.liquid:9
     END
+  end
+
+  def test_dont_report_when_no_missing_space
+    offenses = analyze_theme(
+      ThemeCheck::SpaceInsideBraces.new,
+      "templates/index.liquid" => <<~END,
+        {% comment %}
+        {% endcomment %}
+        {%
+          comment
+        %}
+        {% endcomment %}
+      END
+    )
+    assert_offenses('', offenses)
   end
 
   def test_reports_extra_space

--- a/test/liquid_node_test.rb
+++ b/test/liquid_node_test.rb
@@ -15,20 +15,23 @@ module ThemeCheck
             'foo'
           %}
           {% comment   %}hi{% endcomment %}
+          {%
+            style
+          %}
+          {% endstyle %}
+          {% style%}{% endstyle %}
+          {% if
+          true%}{% endif %}
         </ul>
       END
-      node = find(root) { |n| n.type_name == :if }
-      assert_equal("if true ", node.markup)
-      node = find(root) { |n| n.type_name == :assign }
-      assert_equal("assign x = 1", node.markup)
-      node = find(root) { |n| n.type_name == :echo }
-      assert_equal("echo x", node.markup)
-      node = find(root) { |n| n.type_name == :render }
-      assert_equal("render\n    'foo'\n  ", node.markup)
-      # Note, the following also doesn't return content as expected.
-      # We're getting "comment " back
-      # node = find(root) { |n| n.type_name == :comment }
-      # assert_equal("comment   ", node.markup)
+      assert_can_find_node_with_markup(root, "if true ")
+      assert_can_find_node_with_markup(root, "assign x = 1")
+      assert_can_find_node_with_markup(root, "echo x")
+      assert_can_find_node_with_markup(root, "render\n    'foo'\n  ")
+      assert_can_find_node_with_markup(root, "comment   ")
+      assert_can_find_node_with_markup(root, "style\n  ")
+      assert_can_find_node_with_markup(root, "style")
+      assert_can_find_node_with_markup(root, "if\n  true")
     end
 
     def test_inside_liquid_tag?
@@ -192,6 +195,13 @@ module ThemeCheck
       node.children
         .map { |n| find(n, &block) }
         .find { |n| !n.nil? }
+    end
+
+    def assert_can_find_node_with_markup(root, markup)
+      assert(
+        find(root) { |n| n.markup == markup },
+        "Expected to find node with markup == `#{markup}`"
+      )
     end
   end
 end


### PR DESCRIPTION
Opened dawn with 1.6.1 and saw a bunch of false positives caused by https://github.com/Shopify/theme-check/pull/454.

<img width="736" alt="image" src="https://user-images.githubusercontent.com/4990691/133652074-cd41514a-5300-4efa-a087-e95da4e7b6dd.png">


At some point, I'll have enough unit tests. Really wish we had actual line/col or start_index/end_index in liquid instead. This hack seems really brittle :(.