### PR TITLE
Handle Errno::EADDRNOTAVAIL in RemoteAsset

### DIFF
--- a/lib/theme_check/exceptions.rb
+++ b/lib/theme_check/exceptions.rb
@@ -22,6 +22,7 @@ module ThemeCheck
     Errno::EAGAIN,
     Errno::EHOSTUNREACH,
     Errno::ENETUNREACH,
+    Errno::EADDRNOTAVAIL,
   ]
 
   NET_HTTP_EXCEPTIONS = [

--- a/test/remote_asset_file_test.rb
+++ b/test/remote_asset_file_test.rb
@@ -29,5 +29,11 @@ module ThemeCheck
       refute(asset.gzipped_size)
       refute(asset.content)
     end
+
+    def test_handles_eaddr_not_avail_errors
+      asset = RemoteAssetFile.from_src("https://localhost:0/packs/embed.js")
+      assert(asset.gzipped_size == 0)
+      assert(asset.content.empty?)
+    end
   end
 end


### PR DESCRIPTION
cc @catlee
