### PR TITLE
Edit check docs template

### DIFF
--- a/docs/checks/TEMPLATE.md.erb
+++ b/docs/checks/TEMPLATE.md.erb
@@ -28,7 +28,7 @@ The following example contains the default configuration for this check:
 <%= class_name %>:
   enabled: false
   severity: suggestion
-  threshold_in_bytes: 10_000
+  other_option: 10_000
 ```
 
 | Parameter | Description |


### PR DESCRIPTION
## This PR:

- Adjusts the theme check docs template to make it look more similar to the template we use for theme check on shopify.dev.

This is step 1 of a process to try to make sure that the docs on shopify.dev stop falling so far behind the theme check repo. If the templates are similar, we can look at auto-creating issues or prs that use these docs as a starting point