### PR TITLE
Autocorrection `RequiredLayoutThemeObject`

### DIFF
--- a/lib/theme_check/checks/required_layout_theme_object.rb
+++ b/lib/theme_check/checks/required_layout_theme_object.rb
@@ -27,14 +27,19 @@ module ThemeCheck
     def after_document(node)
       return unless node.theme_file.name == LAYOUT_FILENAME
 
-      add_missing_object_offense("content_for_layout") unless @content_for_layout_found
-      add_missing_object_offense("content_for_header") unless @content_for_header_found
+      add_missing_object_offense("content_for_layout", "</body>") unless @content_for_layout_found
+      add_missing_object_offense("content_for_header", "</head>") unless @content_for_header_found
     end
 
     private
 
-    def add_missing_object_offense(name)
-      add_offense("#{LAYOUT_FILENAME} must include {{#{name}}}", node: @layout_theme_node)
+    def add_missing_object_offense(name, tag)
+      add_offense("#{LAYOUT_FILENAME} must include {{#{name}}}", node: @layout_theme_node) do
+        if @layout_theme_node.source.index(tag)
+          @layout_theme_node.source.insert(@layout_theme_node.source.index(tag), "  {{ #{name} }}\n  ")
+          @layout_theme_node.markup = @layout_theme_node.source
+        end
+      end
     end
   end
 end

--- a/test/checks/required_layout_theme_object_test.rb
+++ b/test/checks/required_layout_theme_object_test.rb
@@ -45,6 +45,91 @@ class RequiredLayoutThemeObjectTest < Minitest::Test
     )
   end
 
+  def test_creates_missing_content_for_layout
+    expected_sources = {
+      "layout/theme.liquid" => <<~END,
+        <!DOCTYPE html>
+        <html>
+          <head>
+            {{ content_for_header }}
+          </head>
+          <body>
+            {{ content_for_layout }}
+          </body>
+        </html>
+      END
+    }
+    sources = fix_theme(
+      ThemeCheck::RequiredLayoutThemeObject.new,
+      "layout/theme.liquid" => <<~END,
+        <!DOCTYPE html>
+        <html>
+          <head>
+            {{ content_for_header }}
+          </head>
+          <body>
+          </body>
+        </html>
+      END
+    )
+    sources.each do |path, source|
+      assert_equal(expected_sources[path], source)
+    end
+  end
+
+  def test_creates_missing_content_for_header
+    expected_sources = {
+      "layout/theme.liquid" => <<~END,
+        <!DOCTYPE html>
+        <html>
+          <head>
+            {{ content_for_header }}
+          </head>
+          <body>
+            {{ content_for_layout }}
+          </body>
+        </html>
+      END
+    }
+    sources = fix_theme(
+      ThemeCheck::RequiredLayoutThemeObject.new,
+      "layout/theme.liquid" => <<~END,
+        <!DOCTYPE html>
+        <html>
+          <head>
+          </head>
+          <body>
+            {{ content_for_layout }}
+          </body>
+        </html>
+      END
+    )
+    sources.each do |path, source|
+      assert_equal(expected_sources[path], source)
+    end
+  end
+
+  def test_no_head_or_body_tag
+    expected_sources = {
+      "layout/theme.liquid" => <<~END,
+        <!DOCTYPE html>
+        <html>
+        </html>
+      END
+    }
+    sources = fix_theme(
+      ThemeCheck::RequiredLayoutThemeObject.new,
+      "layout/theme.liquid" => <<~END,
+        <!DOCTYPE html>
+        <html>
+        </html>
+      END
+    )
+    sources.each do |path, source|
+      assert_equal(expected_sources[path], source)
+    end
+  end
+
   private
 
   def analyze_layout_theme(content)


### PR DESCRIPTION
This check prevents missing {{ content_for_header }} and {{ content_for_layout }} objects in layout/theme.liquid