### PR TITLE
Autocorrection `MissingEnableComment`

### DIFF
--- a/lib/theme_check/checks/missing_enable_comment.rb
+++ b/lib/theme_check/checks/missing_enable_comment.rb
@@ -27,7 +27,8 @@ module ThemeCheck
       end
 
       add_offense("#{message} disabled but not re-enabled with theme-check-enable", node: node) do
-        script = node.source.to_enum(:scan, /(?<comment_open>{% comment %}theme-check-disable)(?<checks>.*?)(?<comment_close>{% endcomment %})(?<enclosed>[^\n]*\n[^\n]*\n)/m).map { Regexp.last_match }[-1]
+        node.source.scan(/(?<comment_open>{% comment %}theme-check-disable)(?<checks>.*?)(?<comment_close>{% endcomment %})(?<enclosed>[^\n]*\n[^\n]*\n)/m)
+        # script = node.source.to_enum(:scan, /(?<comment_open>{% comment %}theme-check-disable)(?<checks>.*?)(?<comment_close>{% endcomment %})(?<enclosed>[^\n]*\n[^\n]*\n)/m).map { Regexp.last_match }[-1]
         next if script.nil?
         node.source.insert(script.end(:enclosed), "{% comment %}theme-check-enable#{checks_missing_end_index.include?(:all) ? "" : " #{checks_missing_end_index.join(', ')}"}{% endcomment %}\n")
       end

--- a/lib/theme_check/checks/missing_enable_comment.rb
+++ b/lib/theme_check/checks/missing_enable_comment.rb
@@ -27,10 +27,10 @@ module ThemeCheck
       end
 
       add_offense("#{message} disabled but not re-enabled with theme-check-enable", node: node) do
-        node.source.scan(/(?<comment_open>{% comment %}theme-check-disable)(?<checks>.*?)(?<comment_close>{% endcomment %})(?<enclosed>[^\n]*\n[^\n]*\n)/m)
-        # script = node.source.to_enum(:scan, /(?<comment_open>{% comment %}theme-check-disable)(?<checks>.*?)(?<comment_close>{% endcomment %})(?<enclosed>[^\n]*\n[^\n]*\n)/m).map { Regexp.last_match }[-1]
+        script = node.source.scan(/{% comment %}theme-check-disable.*?{% endcomment %}[^\n]*\n[^\n]*\n/m).last
         next if script.nil?
-        node.source.insert(script.end(:enclosed), "{% comment %}theme-check-enable#{checks_missing_end_index.include?(:all) ? "" : " #{checks_missing_end_index.join(', ')}"}{% endcomment %}\n")
+        index = node.source.rindex(script) + script.length
+        node.source.insert(index, "{% comment %}theme-check-enable#{checks_missing_end_index.include?(:all) ? "" : " #{checks_missing_end_index.join(', ')}"}{% endcomment %}\n")
       end
     end
   end

--- a/lib/theme_check/checks/missing_enable_comment.rb
+++ b/lib/theme_check/checks/missing_enable_comment.rb
@@ -26,7 +26,11 @@ module ThemeCheck
         checks_missing_end_index.join(', ') + " " + (checks_missing_end_index.size == 1 ? "was" : "were")
       end
 
-      add_offense("#{message} disabled but not re-enabled with theme-check-enable", node: node)
+      add_offense("#{message} disabled but not re-enabled with theme-check-enable", node: node) do
+        script = node.source.to_enum(:scan, /(?<comment_open>{% comment %}theme-check-disable)(?<checks>.*?)(?<comment_close>{% endcomment %})(?<enclosed>[^\n]*\n[^\n]*\n)/m).map { Regexp.last_match }[-1]
+        next if script.nil?
+        node.source.insert(script.end(:enclosed), "{% comment %}theme-check-enable#{checks_missing_end_index.include?(:all) ? "" : " #{checks_missing_end_index.join(', ')}"}{% endcomment %}\n")
+      end
     end
   end
 end

--- a/test/checks/missing_enable_comment_test.rb
+++ b/test/checks/missing_enable_comment_test.rb
@@ -90,4 +90,78 @@ class MissingEnableCommentTest < Minitest::Test
       All checks were disabled but not re-enabled with theme-check-enable at templates/index.liquid
     END
   end
+
+  def test_adds_missing_enable_all
+    expected_sources = {
+      "templates/index.liquid" => <<~END,
+        <p>Hello, world</p>
+        {% comment %}theme-check-disable{% endcomment %}
+        {% assign x = 1 %}
+        {% comment %}theme-check-enable{% endcomment %}
+      END
+    }
+    sources = fix_theme(
+      ThemeCheck::MissingEnableComment.new,
+      "templates/index.liquid" => <<~END,
+        <p>Hello, world</p>
+        {% comment %}theme-check-disable{% endcomment %}
+        {% assign x = 1 %}
+      END
+    )
+    sources.each do |path, source|
+      assert_equal(expected_sources[path], source)
+    end
+  end
+
+  def test_adds_missing_enable_specific_checks
+    expected_sources = {
+      "templates/index.liquid" => <<~END,
+        <p>Hello, world</p>
+        {% comment %}theme-check-disable TracerCheck, AnotherCheck{% endcomment %}
+        {% assign x = 1 %}
+        {% comment %}theme-check-enable TracerCheck, AnotherCheck{% endcomment %}
+      END
+    }
+    sources = fix_theme(
+      ThemeCheck::MissingEnableComment.new,
+      "templates/index.liquid" => <<~END,
+        <p>Hello, world</p>
+        {% comment %}theme-check-disable TracerCheck, AnotherCheck{% endcomment %}
+        {% assign x = 1 %}
+      END
+    )
+    sources.each do |path, source|
+      assert_equal(expected_sources[path], source)
+    end
+  end
+
+  def test_adds_missing_enable_after_last_check_when_multiple_checks_disabled
+    expected_sources = {
+      "templates/index.liquid" => <<~END,
+        <p>Hello, world</p>
+        {% comment %}theme-check-disable OneCheck, TwoCheck{% endcomment %}
+          {% assign x = 1 %}
+        {% comment %}theme-check-disable TracerCheck, AnotherCheck{% endcomment %}
+          {% assign x = 1 %}
+        {% comment %}theme-check-disable{% endcomment %}
+          {% assign x = 1 %}
+        {% comment %}theme-check-enable{% endcomment %}
+      END
+    }
+    sources = fix_theme(
+      ThemeCheck::MissingEnableComment.new,
+      "templates/index.liquid" => <<~END,
+        <p>Hello, world</p>
+        {% comment %}theme-check-disable OneCheck, TwoCheck{% endcomment %}
+          {% assign x = 1 %}
+        {% comment %}theme-check-disable TracerCheck, AnotherCheck{% endcomment %}
+          {% assign x = 1 %}
+        {% comment %}theme-check-disable{% endcomment %}
+          {% assign x = 1 %}
+      END
+    )
+    sources.each do |path, source|
+      assert_equal(expected_sources[path], source)
+    end
+  end
 end

--- a/test/checks/missing_enable_comment_test.rb
+++ b/test/checks/missing_enable_comment_test.rb
@@ -188,4 +188,53 @@ class MissingEnableCommentTest < Minitest::Test
       assert_equal(expected_sources[path], source)
     end
   end
+
+  def test_does_not_correct_first_line_disable
+    expected_sources = {
+      "templates/index.liquid" => <<~END,
+        {% comment %}theme-check-disable{% endcomment %}
+        {% assign x = 1 %}
+      END
+    }
+
+    sources = fix_theme(
+      ThemeCheck::MissingEnableComment.new,
+      "templates/index.liquid" => <<~END,
+        {% comment %}theme-check-disable{% endcomment %}
+        {% assign x = 1 %}
+      END
+    )
+
+    sources.each do |path, source|
+      assert_equal(expected_sources[path], source)
+    end
+  end
+
+  def test_html_check
+    expected_sources = {
+      "templates/index.liquid" => <<~END,
+        <p>Hello, world</p>
+        {% comment %}theme-check-disable ImgWidthAndHeight{% endcomment %}
+        <img src="a.jpg">
+        {% comment %}theme-check-enable ImgWidthAndHeight{% endcomment %}
+        <img src="b.jpg" height="100">
+        <img src="c.jpg" width="100">
+      END
+    }
+
+    sources = fix_theme(
+      ThemeCheck::MissingEnableComment.new,
+      "templates/index.liquid" => <<~END,
+        <p>Hello, world</p>
+        {% comment %}theme-check-disable ImgWidthAndHeight{% endcomment %}
+        <img src="a.jpg">
+        <img src="b.jpg" height="100">
+        <img src="c.jpg" width="100">
+      END
+    )
+
+    sources.each do |path, source|
+      assert_equal(expected_sources[path], source)
+    end
+  end
 end

--- a/test/checks/missing_enable_comment_test.rb
+++ b/test/checks/missing_enable_comment_test.rb
@@ -164,4 +164,28 @@ class MissingEnableCommentTest < Minitest::Test
       assert_equal(expected_sources[path], source)
     end
   end
+
+  def test_comment_insert_location
+    expected_sources = {
+      "templates/index.liquid" => <<~END,
+        <p>Hello, world</p>
+        {% comment %}theme-check-disable{% endcomment %}
+        {% assign x = 1 %}
+        {% comment %}theme-check-enable{% endcomment %}
+        {% assign x = 1 %}
+      END
+    }
+    sources = fix_theme(
+      ThemeCheck::MissingEnableComment.new,
+      "templates/index.liquid" => <<~END,
+        <p>Hello, world</p>
+        {% comment %}theme-check-disable{% endcomment %}
+        {% assign x = 1 %}
+        {% assign x = 1 %}
+      END
+    )
+    sources.each do |path, source|
+      assert_equal(expected_sources[path], source)
+    end
+  end
 end


### PR DESCRIPTION
### What does this do?
When `theme-check-disable` is used in the middle of a theme file, the corresponding `theme-check-enable` comment should gets included.
### What should reviewers focus on?

- Regex used to identify a theme-check enable/disable comment