### PR TITLE
Fix Liquid in HTML parsing

### DIFF
--- a/lib/theme_check/html_node.rb
+++ b/lib/theme_check/html_node.rb
@@ -5,12 +5,75 @@ module ThemeCheck
   class HtmlNode < Node
     extend Forwardable
     include RegexHelpers
+    include PositionHelper
     attr_reader :theme_file, :parent
 
-    def initialize(value, theme_file, placeholder_values = [], parent = nil)
+    class << self
+      include RegexHelpers
+
+      def parse(liquid_file)
+        placeholder_values = []
+        parseable_source = +liquid_file.source.clone
+
+        # Replace all non-empty liquid tags with ≬{i}######≬ to prevent the HTML
+        # parser from freaking out. We transparently replace those placeholders in
+        # HtmlNode.
+        #
+        # We're using base36 to prevent index bleeding on 36^3 tags.
+        # `{{x}}` -> `≬#{i}≬` would properly be transformed for 46656 tags in a single file.
+        # Should be enough.
+        #
+        # The base10 alternative would have overflowed at 1000 (`{{x}}` -> `≬1000≬`) which seemed more likely.
+        #
+        # Didn't go with base64 because of the `=` character that would have messed with HTML parsing.
+        #
+        # (Note, we're also maintaining newline characters in there so
+        # that line numbers match the source...)
+        matches(parseable_source, LIQUID_TAG_OR_VARIABLE).each do |m|
+          value = m[0]
+          next unless value.size > 4 # skip empty tags/variables {%%} and {{}}
+          placeholder_values.push(value)
+          key = (placeholder_values.size - 1).to_s(36)
+
+          # Doing shenanigans so that line numbers match... Ugh.
+          keyed_placeholder = parseable_source[m.begin(0)...m.end(0)]
+
+          # First and last chars are ≬
+          keyed_placeholder[0] = "≬"
+          keyed_placeholder[-1] = "≬"
+
+          # Non newline characters are #
+          keyed_placeholder.gsub!(/[^\n≬]/, '#')
+
+          # First few # are replaced by the base10 ID of the tag
+          i = -1
+          keyed_placeholder.gsub!('#') do
+            i += 1
+            if i > key.size - 1
+              '#'
+            else
+              key[i]
+            end
+          end
+
+          # Replace source by placeholder
+          parseable_source[m.begin(0)...m.end(0)] = keyed_placeholder
+        end
+
+        new(
+          Nokogiri::HTML5.fragment(parseable_source, max_tree_depth: 400, max_attributes: 400),
+          liquid_file,
+          placeholder_values,
+          parseable_source
+        )
+      end
+    end
+
+    def initialize(value, theme_file, placeholder_values, parseable_source, parent = nil)
       @value = value
       @theme_file = theme_file
       @placeholder_values = placeholder_values
+      @parseable_source = parseable_source
       @parent = parent
     end
 
@@ -27,11 +90,11 @@ module ThemeCheck
     def children
       @children ||= @value
         .children
-        .map { |child| HtmlNode.new(child, theme_file, @placeholder_values, self) }
+        .map { |child| HtmlNode.new(child, theme_file, @placeholder_values, @parseable_source, self) }
     end
 
     def markup
-      @markup ||= replace_placeholders(@value.to_html)
+      @markup ||= replace_placeholders(parseable_markup)
     end
 
     def line_number
@@ -39,11 +102,27 @@ module ThemeCheck
     end
 
     def start_index
-      raise NotImplementedError
+      position.start_index
     end
 
     def end_index
-      raise NotImplementedError
+      position.end_index
+    end
+
+    def start_row
+      position.start_row
+    end
+
+    def start_column
+      position.start_column
+    end
+
+    def end_row
+      position.end_row
+    end
+
+    def end_column
+      position.end_column
     end
 
     def literal?
@@ -60,6 +139,12 @@ module ThemeCheck
         .to_h
     end
 
+    def parseable_markup
+      start_index = from_row_column_to_index(@parseable_source, line_number - 1, 0)
+      @parseable_source
+        .match(/<\s*#{@value.name}[^>]*>/im, start_index)[0]
+    end
+
     def content
       @content ||= replace_placeholders(@value.content)
     end
@@ -74,10 +159,18 @@ module ThemeCheck
 
     private
 
+    def position
+      @position ||= Position.new(
+        markup,
+        theme_file.source,
+        line_number_1_indexed: line_number,
+      )
+    end
+
     def replace_placeholders(string)
       # Replace all ≬{i}####≬ with the actual content.
       string.gsub(HTML_LIQUID_PLACEHOLDER) do |match|
-        key = /[0-9a-z]+/.match(match)[0]
+        key = /[0-9a-z]+/.match(match.gsub("\n", ''))[0]
         @placeholder_values[key.to_i(36)]
       end
     end

--- a/lib/theme_check/html_visitor.rb
+++ b/lib/theme_check/html_visitor.rb
@@ -4,7 +4,6 @@ require "forwardable"
 
 module ThemeCheck
   class HtmlVisitor
-    include RegexHelpers
     attr_reader :checks
 
     def initialize(checks)
@@ -12,42 +11,12 @@ module ThemeCheck
     end
 
     def visit_liquid_file(liquid_file)
-      doc, placeholder_values = parse(liquid_file)
-      visit(HtmlNode.new(doc, liquid_file, placeholder_values))
+      visit(HtmlNode.parse(liquid_file))
     rescue ArgumentError => e
       call_checks(:on_parse_error, e, liquid_file)
     end
 
     private
-
-    def parse(liquid_file)
-      placeholder_values = []
-      parseable_source = +liquid_file.source.clone
-
-      # Replace all non-empty liquid tags with ≬{i}######≬ to prevent the HTML
-      # parser from freaking out. We transparently replace those placeholders in
-      # HtmlNode.
-      #
-      # We're using base36 to prevent index bleeding on 36^3 tags.
-      # `{{x}}` -> `≬#{i}≬` would properly be transformed for 46656 tags in a single file.
-      # Should be enough.
-      #
-      # The base10 alternative would have overflowed at 1000 (`{{x}}` -> `≬1000≬`) which seemed more likely.
-      #
-      # Didn't go with base64 because of the `=` character that would have messed with HTML parsing.
-      matches(parseable_source, LIQUID_TAG_OR_VARIABLE).each do |m|
-        value = m[0]
-        next unless value.size > 4 # skip empty tags/variables {%%} and {{}}
-        placeholder_values.push(value)
-        key = (placeholder_values.size - 1).to_s(36)
-        parseable_source[m.begin(0)...m.end(0)] = "≬#{key.ljust(m.end(0) - m.begin(0) - 2, '#')}≬"
-      end
-
-      [
-        Nokogiri::HTML5.fragment(parseable_source, max_tree_depth: 400, max_attributes: 400),
-        placeholder_values,
-      ]
-    end
 
     def visit(node)
       call_checks(:on_element, node) if node.element?

--- a/lib/theme_check/regex_helpers.rb
+++ b/lib/theme_check/regex_helpers.rb
@@ -5,7 +5,7 @@ module ThemeCheck
     LIQUID_TAG = /#{Liquid::TagStart}.*?#{Liquid::TagEnd}/om
     LIQUID_VARIABLE = /#{Liquid::VariableStart}.*?#{Liquid::VariableEnd}/om
     LIQUID_TAG_OR_VARIABLE = /#{LIQUID_TAG}|#{LIQUID_VARIABLE}/om
-    HTML_LIQUID_PLACEHOLDER = /≬[0-9a-z]+#*≬/m
+    HTML_LIQUID_PLACEHOLDER = /≬[0-9a-z\n]+[#\n]*≬/m
     START_OR_END_QUOTE = /(^['"])|(['"]$)/
 
     def matches(s, re)

--- a/test/checks/remote_asset_test.rb
+++ b/test/checks/remote_asset_test.rb
@@ -85,5 +85,22 @@ module ThemeCheck
         Asset should be served by the Shopify CDN for better performance. at templates/index.liquid:2
       END
     end
+
+    def test_offense_location_makes_sense
+      liquid = <<~LIQUID
+        {%
+          if
+          true
+        %}
+          <script
+            src="https://widget.reviews.co.uk/product/dist.js"
+            defer
+          ></script>
+        {% endif %}
+      LIQUID
+      offenses = analyze_theme(RemoteAsset.new, "templates/index.liquid" => liquid)
+      assert_equal(4, offenses[0].start_line)
+      assert_equal(2, offenses[0].start_column)
+    end
   end
 end

--- a/test/html_node_test.rb
+++ b/test/html_node_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module ThemeCheck
+  class HtmlNodeTest < Minitest::Test
+    def test_markup
+      html = <<~HTML
+        <div>
+          {{ 'foo.js' | asset_url | stylesheet_tag }}
+          <link rel="stylesheet" href="{{ "styles.css" | asset_url }}">
+          <script src="abc.js" defer></script>
+          <img
+            data-boolean
+            src="abc.js"
+            loading="lazy"
+            width=100
+            height='
+              {%- if image.height > 5 -%}
+                50
+              {%- else -%}
+                100
+              {%- endif -%}
+            '
+          ></img>
+          <iframe
+            {% if settings.lazy %}
+              loading="lazy"
+            {% else %}
+              loading="eager"
+            {% endif %}
+          ></iframe>
+        </div>
+      HTML
+      root = root_node(html)
+      assert_markup_equals('<div>', root, "div")
+      assert_markup_equals('<link rel="stylesheet" href="{{ "styles.css" | asset_url }}">', root, "link")
+      assert_markup_equals('<script src="abc.js" defer>', root, "script")
+      assert_markup_equals(html[html.index('<img')...html.index('</img>')], root, "img")
+      assert_markup_equals(html[html.index('<iframe')...html.index('</iframe>')], root, "iframe")
+    end
+
+    def test_line_numbers
+      html = <<~HTML
+        <div>
+          {{
+            'foo.js' | asset_url | stylesheet_tag
+          }}
+          <link rel="stylesheet" href="{{ "styles.css" | asset_url }}">
+          <script src="abc.js" defer></script>
+        </div>
+      HTML
+      root = root_node(html)
+      assert_line_number_equals(1, root, "div")
+      assert_line_number_equals(5, root, "link")
+      assert_line_number_equals(6, root, "script")
+    end
+
+    def test_positions
+      html = <<~HTML
+        <div>
+          {{
+            'foo.js' | asset_url | stylesheet_tag
+          }}
+          <img
+            src="abc.js"
+            loading="lazy"
+            width=100
+            height=
+              {%- if image.height > 5 -%}
+                50
+              {%- else -%}
+                100
+              {%- endif -%}
+            data-boolean
+          >
+          </img>
+        </div>
+      HTML
+      root = root_node(html)
+      node = find(root) { |n| n.name == "img" }
+      assert_equal(4, node.start_row)
+      assert_equal(2, node.start_column)
+      assert_equal(15, node.end_row)
+      assert_equal(3, node.end_column)
+    end
+
+    private
+
+    def assert_line_number_equals(expected, root, name)
+      node = find(root) { |n| n.name == name }
+      refute_nil(node, "Expected to find node to test node.markup == '#{expected}'")
+      assert_equal(expected, node.line_number)
+    end
+
+    def assert_markup_equals(expected, root, name)
+      node = find(root) { |n| n.name == name }
+      refute_nil(node, "Expected to find node to test node.markup == '#{expected}'")
+      assert_equal(expected, node.markup)
+    end
+
+    def find(node, &block)
+      return node if block.call(node)
+      return nil if node.children.nil? || node.children.empty?
+      node.children
+        .map { |n| find(n, &block) }
+        .find { |n| !n.nil? }
+    end
+
+    def root_node(code)
+      liquid_file = parse_liquid(code)
+      HtmlNode.parse(liquid_file)
+    end
+  end
+end


### PR DESCRIPTION
We had issues with our parsing hack. When the liquid had new lines in
it, the #{id}######## hack messed with the line numbers.

Also learned today that the HTML parser doesn't provide an accurate
.to_html value. It is _built_ and not what we provided in the source.
Therefore the two are not equal. The only way to find the source markup
is to look for the tag starting at that line in the source itself. Which
we do in this PR.

Also implemented start/end position methods for the HtmlNode while we're
at it.

Also added tests for HtmlNode#markup,#line_number and position methods.

Fixes #502
