### PR TITLE
Make SpaceInsideBraces work for missing cases

### DIFF
--- a/lib/theme_check/checks/space_inside_braces.rb
+++ b/lib/theme_check/checks/space_inside_braces.rb
@@ -6,116 +6,160 @@ module ThemeCheck
     category :liquid
     doc docs_url(__FILE__)
 
-    def initialize
-      @ignore = false
-    end
-
     def on_node(node)
       return unless node.markup
       return if node.literal?
-      return if :assign == node.type_name
+      return if node.assigned_or_echoed_variable?
 
       outside_of_strings(node.markup) do |chunk, chunk_start|
-        chunk.scan(/([,:|]|==|<>|<=|>=|<|>|!=)(  +)/) do |_match|
-          add_offense(
-            "Too many spaces after '#{Regexp.last_match(1)}'",
-            node: node,
-            markup: Regexp.last_match(2),
-            node_markup_offset: chunk_start + Regexp.last_match.begin(2)
-          )
+        chunk.scan(/(?<token>[,:|]|==|<>|<=|>=|<|>|!=)(?<offense>  +)/) do |_match|
+          add_too_many_spaces_after_offense(Regexp.last_match, node, chunk_start)
         end
-        chunk.scan(/([,:|]|==|<>|<=|>=|<\b|>\b|!=)(\S|\z)/) do |_match|
-          add_offense(
-            "Space missing after '#{Regexp.last_match(1)}'",
-            node: node,
-            markup: Regexp.last_match(1),
-            node_markup_offset: chunk_start + Regexp.last_match.begin(0),
-          )
+        chunk.scan(/(?<offense>(?<token>[,:|]|==|<>|<=|>=|<\b|>\b|!=)(\S|\z))/) do |_match|
+          add_space_missing_after_offense(Regexp.last_match, node, chunk_start)
         end
-        chunk.scan(/(  +)(\||==|<>|<=|>=|<|>|!=)+/) do |_match|
-          add_offense(
-            "Too many spaces before '#{Regexp.last_match(2)}'",
-            node: node,
-            markup: Regexp.last_match(1),
-            node_markup_offset: chunk_start + Regexp.last_match.begin(1)
-          )
+        chunk.scan(/(?<offense>\s{2,})(?<token>\||==|<>|<=|>=|<|>|!=)+/) do |_match|
+          unless Regexp.last_match(:offense).include?("\n")
+            add_too_many_spaces_before_offense(Regexp.last_match, node, chunk_start)
+          end
         end
-        chunk.scan(/(\A|\S)(?<match>\||==|<>|<=|>=|<|\b>|!=)/) do |_match|
-          add_offense(
-            "Space missing before '#{Regexp.last_match(1)}'",
-            node: node,
-            markup: Regexp.last_match(:match),
-            node_markup_offset: chunk_start + Regexp.last_match.begin(:match)
-          )
+        chunk.scan(/(\A|\S)(?<offense>(?<token>\||==|<>|<=|>=|<|\b>|!=))/) do |_match|
+          add_space_missing_before_offense(Regexp.last_match, node, chunk_start)
         end
       end
     end
+
+    BlockMarkup = Struct.new(:markup, :node_markup_offset)
 
     def on_tag(node)
-      unless node.inside_liquid_tag?
-        if node.markup[-1] != " " && node.markup[-1] != "\n"
-          add_offense(
-            "Space missing before '#{node.end_token}'",
-            node: node,
-            markup: node.markup[-1],
-            node_markup_offset: node.markup.size - 1,
-          )
-        elsif node.markup =~ /(\n?)(  +)\z/m && Regexp.last_match(1) != "\n"
-          add_offense(
-            "Too many spaces before '#{node.end_token}'",
-            node: node,
-            markup: Regexp.last_match(2),
-            node_markup_offset: node.markup.size - Regexp.last_match(2).size
-          )
-        end
-      end
-      @ignore = true
-    end
+      return if node.inside_liquid_tag?
 
-    def after_tag(_node)
-      @ignore = false
+      # Both the start and end tags
+      blocks = [
+        BlockMarkup.new(node.block_start_markup, node.block_start_start_index - node.start_index),
+        BlockMarkup.new(node.block_end_markup, node.block_end_start_index - node.start_index),
+      ]
+
+      blocks.each do |block|
+        # Looking at spaces after the start token
+        if block.markup =~ /^(?<token>{%-?)(?<offense>[^ \n\t-])/
+          add_space_missing_after_offense(Regexp.last_match, node, block.node_markup_offset)
+        end
+
+        if block.markup =~ /^(?<token>{%-?)(?<offense> {2,})\S/
+          add_too_many_spaces_after_offense(Regexp.last_match, node, block.node_markup_offset)
+        end
+
+        # Looking at spaces before the end token
+        if block.markup =~ /(?<offense>[^ \n\t-])(?<token>-?%})$/
+          add_space_missing_before_offense(Regexp.last_match, node, block.node_markup_offset)
+        end
+
+        if block.markup =~ /\S(?<offense> {2,})(?<token>-?%})$/
+          add_too_many_spaces_before_offense(Regexp.last_match, node, block.node_markup_offset)
+        end
+
+        next
+      end
     end
 
     def on_variable(node)
-      return if @ignore || node.markup.empty?
-      if node.markup[0] != " "
-        add_offense(
-          "Space missing after '#{node.start_token}'",
-          node: node,
-          markup: node.markup[0]
-        ) do |corrector|
-          corrector.insert_before(node, " ")
-        end
+      return if node.markup.empty?
+      return if node.assigned_or_echoed_variable?
+
+      block_start_offset = node.block_start_start_index - node.start_index
+
+      # Looking at spaces after the start token
+      if node.block_start_markup =~ /^(?<token>{{-?)(?<offense>[^ \n\t-])/
+        add_space_missing_after_offense(Regexp.last_match, node, block_start_offset)
       end
-      if node.markup[-1] != " " && node.markup[-1] != "\n"
-        add_offense(
-          "Space missing before '#{node.end_token}'",
-          node: node,
-          markup: node.markup[-1],
-          node_markup_offset: node.markup.size - 1,
-        ) do |corrector|
-          corrector.insert_after(node, " ")
-        end
+
+      if node.block_start_markup =~ /^(?<token>{{-?)(?<offense> {2,})\S/
+        add_too_many_spaces_after_offense(Regexp.last_match, node, block_start_offset)
       end
-      if node.markup =~ /\A(  +)/m
-        add_offense(
-          "Too many spaces after '#{node.start_token}'",
-          node: node,
-          markup: Regexp.last_match(1),
-        ) do |corrector|
-          corrector.replace(node, " #{node.markup.lstrip}")
-        end
+
+      # Looking at spaces before the end token
+      if node.block_start_markup =~ /(?<offense>[^ \n\t-])(?<token>-?}})$/
+        add_space_missing_before_offense(Regexp.last_match, node, block_start_offset)
       end
-      if node.markup =~ /(\n?)(  +)\z/m && Regexp.last_match(1) != "\n"
-        add_offense(
-          "Too many spaces before '#{node.end_token}'",
-          node: node,
-          markup: Regexp.last_match(2),
-          node_markup_offset: node.markup.size - Regexp.last_match(2).size
-        ) do |corrector|
-          corrector.replace(node, "#{node.markup.rstrip} ")
-        end
+
+      if node.block_start_markup =~ /\S(?<offense> {2,})(?<token>-?}})$/
+        add_too_many_spaces_before_offense(Regexp.last_match, node, block_start_offset)
       end
+    end
+
+    def add_space_missing_after_offense(match, node, source_offset)
+      add_offense_for_match(
+        "Space missing after '#{match[:token]}'",
+        match,
+        node,
+        source_offset
+      ) do |corrector|
+        corrector.insert_after(
+          node,
+          ' ',
+          (node.start_index + source_offset + match.begin(:token))...
+          (node.start_index + source_offset + match.end(:token))
+        )
+      end
+    end
+
+    def add_too_many_spaces_after_offense(match, node, source_offset)
+      add_offense_for_match(
+        "Too many spaces after '#{match[:token]}'",
+        match,
+        node,
+        source_offset
+      ) do |corrector|
+        corrector.replace(
+          node,
+          ' ',
+          (node.start_index + source_offset + match.begin(:offense))...
+          (node.start_index + source_offset + match.end(:offense))
+        )
+      end
+    end
+
+    def add_space_missing_before_offense(match, node, source_offset)
+      add_offense_for_match(
+        "Space missing before '#{match[:token]}'",
+        match,
+        node,
+        source_offset
+      ) do |corrector|
+        corrector.insert_before(
+          node,
+          ' ',
+          (node.start_index + source_offset + match.begin(:token))...
+          (node.start_index + source_offset + match.end(:token))
+        )
+      end
+    end
+
+    def add_too_many_spaces_before_offense(match, node, source_offset)
+      add_offense_for_match(
+        "Too many spaces before '#{match[:token]}'",
+        match,
+        node,
+        source_offset
+      ) do |corrector|
+        corrector.replace(
+          node,
+          ' ',
+          (node.start_index + source_offset + match.begin(:offense))...
+          (node.start_index + source_offset + match.end(:offense))
+        )
+      end
+    end
+
+    def add_offense_for_match(message, match, node, source_offset, &block)
+      add_offense(
+        message,
+        node: node,
+        markup: match[:offense],
+        node_markup_offset: source_offset + match.begin(:offense),
+        &block
+      )
     end
   end
 end

--- a/lib/theme_check/corrector.rb
+++ b/lib/theme_check/corrector.rb
@@ -8,20 +8,20 @@ module ThemeCheck
       @theme_file = theme_file
     end
 
-    def insert_after(node, content)
-      @theme_file.rewriter.insert_after(node, content)
+    def insert_after(node, content, character_range = nil)
+      @theme_file.rewriter.insert_after(node, content, character_range)
     end
 
-    def insert_before(node, content)
-      @theme_file.rewriter.insert_before(node, content)
+    def insert_before(node, content, character_range = nil)
+      @theme_file.rewriter.insert_before(node, content, character_range)
     end
 
     def remove(node)
       @theme_file.rewriter.remove(node)
     end
 
-    def replace(node, content)
-      @theme_file.rewriter.replace(node, content)
+    def replace(node, content, character_range = nil)
+      @theme_file.rewriter.replace(node, content, character_range)
       node.markup = content
     end
 

--- a/lib/theme_check/language_server/document_change_corrector.rb
+++ b/lib/theme_check/language_server/document_change_corrector.rb
@@ -20,24 +20,33 @@ module ThemeCheck
       end
 
       # @param node [Node]
-      def insert_before(node, content)
+      def insert_before(node, content, character_range = nil)
+        position = character_range_position(node, character_range) if character_range
         edits(node) << {
-          range: { start: start_position(node), end: start_position(node) },
+          range: {
+            start: start_location(position || node),
+            end: start_location(position || node),
+          },
           newText: content,
         }
       end
 
       # @param node [Node]
-      def insert_after(node, content)
+      def insert_after(node, content, character_range = nil)
+        position = character_range_position(node, character_range) if character_range
         edits(node) << {
-          range: { start: end_position(node), end: end_position(node) },
+          range: {
+            start: end_location(position || node),
+            end: end_location(position || node),
+          },
           newText: content,
         }
       end
 
-      def replace(node, content)
+      def replace(node, content, character_range = nil)
+        position = character_range_position(node, character_range) if character_range
         edits(node) << {
-          range: range(node),
+          range: range(position || node),
           newText: content,
         }
       end
@@ -187,22 +196,32 @@ module ThemeCheck
         node.theme_file&.path
       end
 
+      def character_range_position(node, character_range)
+        return unless character_range
+        source = node.theme_file.source
+        StrictPosition.new(
+          source[character_range],
+          source,
+          character_range.begin,
+        )
+      end
+
       # @param node [ThemeCheck::Node]
       def range(node)
         {
-          start: start_position(node),
-          end: end_position(node),
+          start: start_location(node),
+          end: end_location(node),
         }
       end
 
-      def start_position(node)
+      def start_location(node)
         {
           line: node.start_row,
           character: node.start_column,
         }
       end
 
-      def end_position(node)
+      def end_location(node)
         {
           line: node.end_row,
           character: node.end_column,

--- a/lib/theme_check/offense.rb
+++ b/lib/theme_check/offense.rb
@@ -39,31 +39,17 @@ module ThemeCheck
       end
 
       @node = node
-      @theme_file = nil
-      if node
-        @theme_file = node.theme_file
-      elsif theme_file
-        @theme_file = theme_file
-      end
-
-      @markup = if markup
-        markup
-      else
-        node&.markup
-      end
+      @theme_file = node&.theme_file || theme_file
+      @markup = markup || node&.markup
 
       raise ArgumentError, "Offense markup cannot be an empty string" if @markup.is_a?(String) && @markup.empty?
 
-      @line_number = if line_number
-        line_number
-      elsif @node
-        @node.line_number
-      end
+      @line_number = line_number || @node&.line_number
 
       @position = Position.new(
         @markup,
         @theme_file&.source,
-        line_number_1_indexed: @line_number,
+        line_number_1_indexed: line_number,
         node_markup_offset: node_markup_offset,
         node_markup: node&.markup
       )

--- a/lib/theme_check/theme_file_rewriter.rb
+++ b/lib/theme_check/theme_file_rewriter.rb
@@ -11,16 +11,22 @@ module ThemeCheck
       )
     end
 
-    def insert_before(node, content)
+    def insert_before(node, content, character_range = nil)
       @rewriter.insert_before(
-        range(node.start_index, node.end_index),
+        range(
+          character_range&.begin || node.start_index,
+          character_range&.end || node.end_index,
+        ),
         content
       )
     end
 
-    def insert_after(node, content)
+    def insert_after(node, content, character_range = nil)
       @rewriter.insert_after(
-        range(node.start_index, node.end_index),
+        range(
+          character_range&.begin || node.start_index,
+          character_range&.end || node.end_index,
+        ),
         content
       )
     end
@@ -31,9 +37,12 @@ module ThemeCheck
       )
     end
 
-    def replace(node, content)
+    def replace(node, content, character_range = nil)
       @rewriter.replace(
-        range(node.start_index, node.end_index),
+        range(
+          character_range&.begin || node.start_index,
+          character_range&.end || node.end_index,
+        ),
         content
       )
     end

--- a/test/checks/space_inside_braces_test.rb
+++ b/test/checks/space_inside_braces_test.rb
@@ -14,8 +14,7 @@ class SpaceInsideBracesTest < Minitest::Test
         {{ x-}}
         {{x }}
         {{-x }}
-        {%comment%}
-        {% endcomment %}
+        {%comment%}{%-endcomment-%}
       END
     )
     assert_offenses(<<~END, offenses)
@@ -27,7 +26,10 @@ class SpaceInsideBracesTest < Minitest::Test
       Space missing before '-}}' at templates/index.liquid:6
       Space missing after '{{' at templates/index.liquid:7
       Space missing after '{{-' at templates/index.liquid:8
+      Space missing after '{%' at templates/index.liquid:9
+      Space missing after '{%-' at templates/index.liquid:9
       Space missing before '%}' at templates/index.liquid:9
+      Space missing before '-%}' at templates/index.liquid:9
     END
   end
 
@@ -41,6 +43,22 @@ class SpaceInsideBracesTest < Minitest::Test
           comment
         %}
         {% endcomment %}
+        {%
+          assign x = 'hi'
+          | upcase
+        %}
+        {{
+          color
+          | color_to_hsl
+          | remove: "hsl("
+          | remove: ")"
+        }}
+        {{
+          color |
+          color_to_hsl |
+          remove: "hsl(" |
+          remove: ")"
+        }}
       END
     )
     assert_offenses('', offenses)
@@ -52,19 +70,23 @@ class SpaceInsideBracesTest < Minitest::Test
       "templates/index.liquid" => <<~END,
         {{  x }}
         {{-  x }}
-        {% assign x = 1  %}
-        {% assign x = 1  -%}
+        {%  assign x = 1 %}
+        {%-  assign x = 1 -%}
         {{ x  }}
         {{ x  -}}
+        {% assign x = 1  %}
+        {% assign x = 1  -%}
       END
     )
     assert_offenses(<<~END, offenses)
       Too many spaces after '{{' at templates/index.liquid:1
       Too many spaces after '{{-' at templates/index.liquid:2
-      Too many spaces before '%}' at templates/index.liquid:3
-      Too many spaces before '-%}' at templates/index.liquid:4
+      Too many spaces after '{%' at templates/index.liquid:3
+      Too many spaces after '{%-' at templates/index.liquid:4
       Too many spaces before '}}' at templates/index.liquid:5
       Too many spaces before '-}}' at templates/index.liquid:6
+      Too many spaces before '%}' at templates/index.liquid:7
+      Too many spaces before '-%}' at templates/index.liquid:8
     END
   end
 
@@ -90,6 +112,8 @@ class SpaceInsideBracesTest < Minitest::Test
         {{ url |  asset_url | img_tag }}
         {% assign my_upcase_string = "Hello world"  | upcase %}
         {% assign my_upcase_string = "Hello world" |  upcase %}
+        {% echo "Hello world"  | upcase %}
+        {% echo "Hello world" |  upcase %}
       END
     )
     assert_offenses(<<~END, offenses)
@@ -97,6 +121,8 @@ class SpaceInsideBracesTest < Minitest::Test
       Too many spaces after '|' at templates/index.liquid:2
       Too many spaces before '|' at templates/index.liquid:3
       Too many spaces after '|' at templates/index.liquid:4
+      Too many spaces before '|' at templates/index.liquid:5
+      Too many spaces after '|' at templates/index.liquid:6
     END
   end
 

--- a/test/corrector_test.rb
+++ b/test/corrector_test.rb
@@ -29,6 +29,22 @@ module ThemeCheck
       assert_equal("{{1 + 2 }}", @theme_file.source_excerpt(2))
     end
 
+    def test_insert_after_character_range_adds_suffix_to_character_range
+      node = stub(
+        theme_file: @theme_file,
+        start_index: @contents.index('1'),
+        end_index: @contents.index('2') + 1,
+      )
+      corrector = Corrector.new(theme_file: @theme_file)
+      corrector.insert_after(
+        node,
+        "hi muffin",
+        @contents.index("{{1 + 2}}")...@contents.index("{{1 + 2}}") + "{{1 + 2}}".size,
+      )
+      @theme_file.write
+      assert_equal("{{1 + 2}}hi muffin", @theme_file.source_excerpt(2))
+    end
+
     def test_insert_before_adds_prefix
       node = stub(
         theme_file: @theme_file,
@@ -39,6 +55,22 @@ module ThemeCheck
       corrector.insert_before(node, " ")
       @theme_file.write
       assert_equal("{{ 1 + 2}}", @theme_file.source_excerpt(2))
+    end
+
+    def test_insert_before_character_range_adds_prefix_to_character_range
+      node = stub(
+        theme_file: @theme_file,
+        start_index: @contents.index('1'),
+        end_index: @contents.index('2') + 1,
+      )
+      corrector = Corrector.new(theme_file: @theme_file)
+      corrector.insert_before(
+        node,
+        "hi muffin",
+        @contents.index("{{1 + 2}}")...@contents.index("{{1 + 2}}") + "{{1 + 2}}".size
+      )
+      @theme_file.write
+      assert_equal("hi muffin{{1 + 2}}", @theme_file.source_excerpt(2))
     end
 
     def test_replace_replaces_markup
@@ -52,6 +84,23 @@ module ThemeCheck
       corrector.replace(node, "3 + 4")
       @theme_file.write
       assert_equal("{{3 + 4}}", @theme_file.source_excerpt(2))
+    end
+
+    def test_replace_character_range_replaces_character_range
+      node = stub(
+        theme_file: @theme_file,
+        start_index: @contents.index('1'),
+        end_index: @contents.index('2') + 1,
+        :markup= => ()
+      )
+      corrector = Corrector.new(theme_file: @theme_file)
+      corrector.replace(
+        node,
+        "hi muffin",
+        @contents.index("{1 + 2}")...@contents.index("{1 + 2}") + "{1 + 2}".size
+      )
+      @theme_file.write
+      assert_equal("{hi muffin}", @theme_file.source_excerpt(2))
     end
 
     def test_wrap_adds_prefix_and_suffix

--- a/test/language_server/document_change_corrector_test.rb
+++ b/test/language_server/document_change_corrector_test.rb
@@ -50,6 +50,26 @@ module ThemeCheck
         )
       end
 
+      def test_insert_before_character_range
+        @corrector.insert_before(@node, ' ', 1...5)
+        assert_equal(2, @node.start_column)
+        assert_equal(
+          [
+            {
+              textDocument: {
+                uri: file_uri(@node.theme_file.path),
+                version: nil,
+              },
+              edits: [{
+                range: range(0, 1, 0, 1),
+                newText: ' ',
+              }],
+            },
+          ],
+          @corrector.document_changes
+        )
+      end
+
       def test_insert_after
         @corrector.insert_after(@node, ' ')
         assert_equal(3, @node.end_column)
@@ -70,6 +90,26 @@ module ThemeCheck
         )
       end
 
+      def test_insert_after_character_range
+        @corrector.insert_after(@node, ' ', 0...5)
+        assert_equal(3, @node.end_column)
+        assert_equal(
+          [
+            {
+              textDocument: {
+                uri: file_uri(@node.theme_file.path),
+                version: nil,
+              },
+              edits: [{
+                range: range(0, 5, 0, 5),
+                newText: ' ',
+              }],
+            },
+          ],
+          @corrector.document_changes
+        )
+      end
+
       def test_replace
         @corrector.replace(@node, 'y')
         assert_equal(3, @node.end_column)
@@ -82,6 +122,26 @@ module ThemeCheck
               },
               edits: [{
                 range: range(0, 2, 0, 3),
+                newText: 'y',
+              }],
+            },
+          ],
+          @corrector.document_changes
+        )
+      end
+
+      def test_replace_character_range
+        @corrector.replace(@node, 'y', 0...5)
+        assert_equal(3, @node.end_column)
+        assert_equal(
+          [
+            {
+              textDocument: {
+                uri: file_uri(@node.theme_file.path),
+                version: nil,
+              },
+              edits: [{
+                range: range(0, 0, 0, 5),
                 newText: 'y',
               }],
             },

--- a/test/liquid_node_test.rb
+++ b/test/liquid_node_test.rb
@@ -7,7 +7,7 @@ module ThemeCheck
       root = root_node(<<~END)
         <ul class="{% if true %}list{% endif %}>
           <li>{% liquid
-            assign x = 1
+            assign x = product | foo
             echo x
           %}</li>
           {%
@@ -22,16 +22,23 @@ module ThemeCheck
           {% style%}{% endstyle %}
           {% if
           true%}{% endif %}
+          {{ 'x' }}
+          {{
+            'x'
+          }}
         </ul>
       END
       assert_can_find_node_with_markup(root, "if true ")
-      assert_can_find_node_with_markup(root, "assign x = 1")
+      assert_can_find_node_with_markup(root, "assign x = product | foo")
+      assert_can_find_node_with_markup(root, "product | foo") # the Variable in the assign
       assert_can_find_node_with_markup(root, "echo x")
       assert_can_find_node_with_markup(root, "render\n    'foo'\n  ")
       assert_can_find_node_with_markup(root, "comment   ")
       assert_can_find_node_with_markup(root, "style\n  ")
       assert_can_find_node_with_markup(root, "style")
       assert_can_find_node_with_markup(root, "if\n  true")
+      assert_can_find_node_with_markup(root, " 'x' ")
+      assert_can_find_node_with_markup(root, "\n    'x'\n  ")
     end
 
     def test_inside_liquid_tag?
@@ -463,6 +470,7 @@ module ThemeCheck
     def test_outer_markup
       assert_can_find_node_with_outer_markup("literal\n")
       assert_can_find_node_with_outer_markup('{{x}}')
+      assert_can_find_node_with_outer_markup('{{-x-}}')
       assert_can_find_node_with_outer_markup('{{ x }}')
       assert_can_find_node_with_outer_markup('{%  assign x = 1 %}')
       assert_can_find_node_with_outer_markup('{%assign x = 1%}')

--- a/test/offense_test.rb
+++ b/test/offense_test.rb
@@ -130,7 +130,7 @@ class OffenseTest < Minitest::Test
     assert_equal(0, offense.start_row)
     assert_equal(0, offense.end_row)
     assert_equal(0, offense.start_column)
-    assert_equal(3, offense.end_column)
+    assert_equal(0, offense.end_column)
   end
 
   def test_equal

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -125,10 +125,10 @@ module Minitest
       end
 
       assert_equal(
-        output.chomp,
+        output.split("\n"),
         offenses
           .sort_by { |o| [o.location, o.message].join(' ') }
-          .join("\n")
+          .map(&:to_s)
       )
     end
 


### PR DESCRIPTION
Now that we have outer_markup and inner_markup. It's much easier to fix the problems we had in SpaceInsideBraces.

Biggest problem was that lots of things were not covered.

![](https://screenshot.click/23-58-nqgjz-1saqx.png)
![](https://screenshot.click/23-58-ilk5k-qjq09.png)

Now they are.

Bonus: they _all_ have a corrector block now. So _all_ SpaceInsideBrace offenses can be corrected. 

Fixes #508 