### PR TITLE
Add checkOn{Open,Change,Save} Language Server Configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,13 @@ DeprecateLazysizes:
   enabled: true
   severity: error
 ```
+
+## Language Server Configurations
+
+- `themeCheck.checkOnOpen` (default: `true`) makes it so theme check runs on file open.
+- `themeCheck.checkOnChange` (default: `true`) makes it so theme check runs on file change.
+- `themeCheck.checkOnSave` (default: `true`) makes it so theme check runs on file save.
+
+⚠️ **Note:** Quickfixes only work on a freshly checked file. If any of those configurations are turned off, you will need to rerun theme-check in order to apply quickfixes.
+
+In VS Code, these can be set directly in your `settings.json`.

--- a/lib/theme_check.rb
+++ b/lib/theme_check.rb
@@ -56,6 +56,10 @@ module ThemeCheck
     ENV["THEME_CHECK_DEBUG"] == "true"
   end
 
+  def self.debug_log_file
+    ENV["THEME_CHECK_DEBUG_LOG_FILE"]
+  end
+
   def self.with_liquid_c_disabled
     if defined?(Liquid::C)
       was_enabled = Liquid::C.enabled

--- a/lib/theme_check/language_server.rb
+++ b/lib/theme_check/language_server.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative "language_server/protocol"
 require_relative "language_server/constants"
+require_relative "language_server/configuration"
 require_relative "language_server/channel"
 require_relative "language_server/messenger"
 require_relative "language_server/io_messenger"

--- a/lib/theme_check/language_server/client_capabilities.rb
+++ b/lib/theme_check/language_server/client_capabilities.rb
@@ -10,6 +10,18 @@ module ThemeCheck
       def supports_work_done_progress?
         @capabilities.dig(:window, :workDoneProgress) || false
       end
+
+      def supports_workspace_configuration?
+        @capabilities.dig(:workspace, :configuration) || false
+      end
+
+      def supports_workspace_did_change_configuration_dynamic_registration?
+        @capabilities.dig(:workspace, :didChangeConfiguration, :dynamicRegistration) || false
+      end
+
+      def initialization_option(key)
+        @capabilities.dig(:initializationOptions, key)
+      end
     end
   end
 end

--- a/lib/theme_check/language_server/configuration.rb
+++ b/lib/theme_check/language_server/configuration.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module ThemeCheck
+  module LanguageServer
+    class Configuration
+      CHECK_ON_OPEN = :"themeCheck.checkOnOpen"
+      CHECK_ON_SAVE = :"themeCheck.checkOnSave"
+      CHECK_ON_CHANGE = :"themeCheck.checkOnChange"
+
+      def initialize(bridge, capabilities)
+        @bridge = bridge
+        @capabilities = capabilities
+        @mutex = Mutex.new
+        @initialized = false
+        @config = {
+          CHECK_ON_OPEN => @capabilities.initialization_option(CHECK_ON_OPEN) || true,
+          CHECK_ON_SAVE => @capabilities.initialization_option(CHECK_ON_SAVE) || true,
+          CHECK_ON_CHANGE => @capabilities.initialization_option(CHECK_ON_CHANGE) || true,
+        }
+      end
+
+      def fetch(force: nil)
+        @mutex.synchronize do
+          return unless @capabilities.supports_workspace_configuration?
+          return if initialized? && !force
+          check_on_open, check_on_save, check_on_change = @bridge.send_request(
+            "workspace/configuration",
+            items: [
+              { section: CHECK_ON_OPEN },
+              { section: CHECK_ON_SAVE },
+              { section: CHECK_ON_CHANGE },
+            ],
+          )
+          @config[CHECK_ON_OPEN] = check_on_open unless check_on_open.nil?
+          @config[CHECK_ON_CHANGE] = check_on_change unless check_on_change.nil?
+          @config[CHECK_ON_SAVE] = check_on_save unless check_on_save.nil?
+          @initialized = true
+        end
+      end
+
+      def register_did_change_capability
+        return unless @capabilities.supports_workspace_did_change_configuration_dynamic_registration?
+        @bridge.send_request('client/registerCapability', registrations: [{
+          id: "workspace/didChangeConfiguration",
+          method: "workspace/didChangeConfiguration",
+        }])
+      end
+
+      def initialized?
+        @initialized
+      end
+
+      def check_on_open?
+        fetch # making sure we have an initialized value
+        @config[CHECK_ON_OPEN]
+      end
+
+      def check_on_save?
+        fetch # making sure we have for an initialized value
+        @config[CHECK_ON_SAVE]
+      end
+
+      def check_on_change?
+        fetch # making sure we have for an initialized value
+        @config[CHECK_ON_CHANGE]
+      end
+    end
+  end
+end

--- a/lib/theme_check/language_server/diagnostics_engine.rb
+++ b/lib/theme_check/language_server/diagnostics_engine.rb
@@ -19,14 +19,14 @@ module ThemeCheck
         @diagnostics_manager.first_run?
       end
 
-      def analyze_and_send_offenses(absolute_path, config)
+      def analyze_and_send_offenses(absolute_path, config, force: false)
         return unless @diagnostics_lock.try_lock
         @token += 1
         @bridge.send_create_work_done_progress_request(@token)
         theme = ThemeCheck::Theme.new(storage)
         analyzer = ThemeCheck::Analyzer.new(theme, config.enabled_checks)
 
-        if @diagnostics_manager.first_run?
+        if @diagnostics_manager.first_run? || force
           @bridge.send_work_done_progress_begin(@token, "Full theme check")
           @bridge.log("Checking #{storage.root}")
           offenses = nil

--- a/lib/theme_check/language_server/execute_command_engine.rb
+++ b/lib/theme_check/language_server/execute_command_engine.rb
@@ -3,11 +3,12 @@
 module ThemeCheck
   module LanguageServer
     class ExecuteCommandEngine
-      def initialize(storage, bridge, diagnostics_manager)
+      def initialize
         @providers = {}
-        ExecuteCommandProvider.all
-          .map { |c| c.new(storage, bridge, diagnostics_manager) }
-          .each { |p| @providers[p.command] = p }
+      end
+
+      def <<(provider)
+        @providers[provider.command] = provider
       end
 
       def execute(command, arguments)

--- a/lib/theme_check/language_server/execute_command_provider.rb
+++ b/lib/theme_check/language_server/execute_command_provider.rb
@@ -18,14 +18,6 @@ module ThemeCheck
         end
       end
 
-      attr_reader :storage, :bridge, :diagnostics_manager
-
-      def initialize(storage, bridge, diagnostics_manager)
-        @storage = storage
-        @bridge = bridge
-        @diagnostics_manager = diagnostics_manager
-      end
-
       def execute(arguments)
         raise NotImplementedError
       end

--- a/lib/theme_check/language_server/execute_command_providers/correction_execute_command_provider.rb
+++ b/lib/theme_check/language_server/execute_command_providers/correction_execute_command_provider.rb
@@ -7,6 +7,14 @@ module ThemeCheck
 
       command "correction"
 
+      attr_reader :storage, :bridge, :diagnostics_manager
+
+      def initialize(storage, bridge, diagnostics_manager)
+        @storage = storage
+        @bridge = bridge
+        @diagnostics_manager = diagnostics_manager
+      end
+
       # The arguments passed to this method are the ones forwarded
       # from the selected CodeAction by the client.
       #

--- a/lib/theme_check/language_server/execute_command_providers/run_checks_execute_command_provider.rb
+++ b/lib/theme_check/language_server/execute_command_providers/run_checks_execute_command_provider.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ThemeCheck
+  module LanguageServer
+    class RunChecksExecuteCommandProvider < ExecuteCommandProvider
+      include URIHelper
+
+      command "runChecks"
+
+      def initialize(diagnostics_engine, root_path, root_config)
+        @diagnostics_engine = diagnostics_engine
+        @root_path = root_path
+        @root_config = root_config
+      end
+
+      def execute(_args)
+        @diagnostics_engine.analyze_and_send_offenses(@root_path, @root_config, force: true)
+        nil
+      end
+    end
+  end
+end

--- a/lib/theme_check/language_server/handler.rb
+++ b/lib/theme_check/language_server/handler.rb
@@ -53,7 +53,9 @@ module ThemeCheck
         @completion_engine = CompletionEngine.new(@storage)
         @document_link_engine = DocumentLinkEngine.new(@storage)
         @diagnostics_engine = DiagnosticsEngine.new(@storage, @bridge, @diagnostics_manager)
-        @execute_command_engine = ExecuteCommandEngine.new(@storage, @bridge, @diagnostics_manager)
+        @execute_command_engine = ExecuteCommandEngine.new
+        @execute_command_engine << CorrectionExecuteCommandProvider.new(@storage, @bridge, @diagnostics_manager)
+        @execute_command_engine << RunChecksExecuteCommandProvider.new(@diagnostics_engine, @root_path, config_for_path(@root_path))
         @code_action_engine = CodeActionEngine.new(@storage, @diagnostics_manager)
         @bridge.send_response(id, {
           capabilities: CAPABILITIES,

--- a/lib/theme_check/language_server/io_messenger.rb
+++ b/lib/theme_check/language_server/io_messenger.rb
@@ -3,10 +3,18 @@
 module ThemeCheck
   module LanguageServer
     class IOMessenger < Messenger
+      def self.err_stream
+        if ThemeCheck.debug_log_file
+          File.open(ThemeCheck.debug_log_file, "w")
+        else
+          STDERR
+        end
+      end
+
       def initialize(
         in_stream: STDIN,
         out_stream: STDOUT,
-        err_stream: STDERR
+        err_stream: IOMessenger.err_stream
       )
         validate!([in_stream, out_stream, err_stream])
 


### PR DESCRIPTION
Fixes #510

- Add Configuration support
  - `themeCheck.checkOnOpen` (default: `true`) makes it so theme check runs on file open.
  - `themeCheck.checkOnChange` (default: `true`) makes it so theme check runs on file change.
  - `themeCheck.checkOnSave` (default: `true`) makes it so theme check runs on file save.
- Add a `RunChecksExecuteCommandProvider`
  - So that a user would be able to run a full theme check manually from a command prompt (e.g. cmd+p in VS Code).

Bonus:

- Add THEME_CHECK_DEBUG_LOG_FILE env var for nvim LSP debugging
