### PR TITLE
Fix MatchingTranslations check + corrections

### DIFF
--- a/lib/theme_check/checks/matching_translations.rb
+++ b/lib/theme_check/checks/matching_translations.rb
@@ -13,6 +13,7 @@ module ThemeCheck
     def on_file(file)
       return unless file.name.start_with?("locales/")
       return unless file.content.is_a?(Hash)
+      return if file.name =~ /\.schema$/
       return if file.name == @theme.default_locale_json&.name
 
       @files << file

--- a/lib/theme_check/corrector.rb
+++ b/lib/theme_check/corrector.rb
@@ -54,5 +54,11 @@ module ThemeCheck
       SchemaHelper.set(hash, path, value)
       json_file.update_contents(hash)
     end
+
+    def remove_translation(json_file, path)
+      hash = json_file.content
+      SchemaHelper.delete(hash, path)
+      json_file.update_contents(hash)
+    end
   end
 end

--- a/lib/theme_check/locale_diff.rb
+++ b/lib/theme_check/locale_diff.rb
@@ -37,6 +37,12 @@ module ThemeCheck
           end
           corrector.replace_inner_json(node, schema)
         end
+      elsif theme_file.is_a?(JsonFile)
+        check.add_offense(message, theme_file: theme_file) do |corrector|
+          extra_keys.each do |k|
+            corrector.remove_translation(theme_file, key_prefix + k)
+          end
+        end
       else
         check.add_offense(message, theme_file: theme_file)
       end
@@ -50,6 +56,12 @@ module ThemeCheck
             SchemaHelper.set(schema, key_prefix + k, "TODO")
           end
           corrector.replace_inner_json(node, schema)
+        end
+      elsif theme_file.is_a?(JsonFile)
+        check.add_offense(message, theme_file: theme_file) do |corrector|
+          missing_keys.each do |k|
+            corrector.add_translation(theme_file, key_prefix + k, "TODO")
+          end
         end
       else
         check.add_offense(message, theme_file: theme_file)

--- a/lib/theme_check/offense.rb
+++ b/lib/theme_check/offense.rb
@@ -69,12 +69,16 @@ module ThemeCheck
 
     def in_range?(other_range)
       # Zero length ranges are OK and considered the same as size 1 ranges
-      other_range = other_range.first...(other_range.first + 1) if other_range.size == 0 # rubocop:disable Style/ZeroLengthPredicate
+      other_range = other_range.first..other_range.end if other_range.size == 0 # rubocop:disable Style/ZeroLengthPredicate
       range.cover?(other_range) || other_range.cover?(range)
     end
 
     def range
-      @range ||= (start_index...end_index) # end_index is excluded
+      @range ||= if start_index == end_index
+        (start_index..end_index)
+      else
+        (start_index...end_index) # end_index is excluded
+      end
     end
 
     def start_index

--- a/lib/theme_check/theme.rb
+++ b/lib/theme_check/theme.rb
@@ -3,7 +3,7 @@ require "pathname"
 
 module ThemeCheck
   class Theme
-    DEFAULT_LOCALE_REGEXP = %r{^locales/(.*)\.default}
+    DEFAULT_LOCALE_REGEXP = %r{locales/(.*)\.default$}
     LIQUID_REGEX = /\.liquid$/i
     JSON_REGEX = /\.json$/i
 

--- a/lib/theme_check/theme.rb
+++ b/lib/theme_check/theme.rb
@@ -3,7 +3,7 @@ require "pathname"
 
 module ThemeCheck
   class Theme
-    DEFAULT_LOCALE_REGEXP = %r{^locales/(.*)\.default$}
+    DEFAULT_LOCALE_REGEXP = %r{^locales/(.*)\.default}
     LIQUID_REGEX = /\.liquid$/i
     JSON_REGEX = /\.json$/i
 

--- a/test/checks/matching_translations_test.rb
+++ b/test/checks/matching_translations_test.rb
@@ -174,4 +174,25 @@ class MatchingTranslationsTest < Minitest::Test
 
     assert_offenses("", offenses)
   end
+
+  def test_ignore_schema_json_locale_files
+    offenses = analyze_theme(
+      ThemeCheck::MatchingTranslations.new,
+      "locales/en.default.json" => JSON.dump(
+        hello: "Hello",
+        shopify: {
+          checkout: {
+            general: {
+              page_title: 'Checkout',
+            },
+          },
+        },
+      ),
+      "locales/fr.schema.json" => JSON.dump(
+        hello: "Bonjour",
+      ),
+    )
+
+    assert_offenses("", offenses)
+  end
 end

--- a/test/offense_test.rb
+++ b/test/offense_test.rb
@@ -175,4 +175,22 @@ class OffenseTest < Minitest::Test
     # False for zero length range outside the range
     refute(offense.in_range?(10...10))
   end
+
+  def test_offense_in_range_zero_length_offense
+    theme_file = stub(source: '{ "json_file_without_line_numbers": "ok" }')
+    offense = ThemeCheck::Offense.new(
+      check: Bogus.new,
+      theme_file: theme_file,
+    )
+
+    # Showing the assumption
+    assert_equal(offense.range, 0..0)
+
+    # True when highlighting over the error
+    assert(offense.in_range?(0..0))
+    assert(offense.in_range?(0...0))
+
+    # False for no overlap
+    refute(offense.in_range?(1...5))
+  end
 end

--- a/test/theme_test.rb
+++ b/test/theme_test.rb
@@ -9,12 +9,13 @@ class ThemeTest < Minitest::Test
       "templates/index.liquid" => "",
       "snippets/product.liquid" => "",
       "sections/article-template/template.liquid" => "",
-      "locales/en.default.json" => "",
+      "locales/fr.default.json" => "",
+      "locales/en.json" => "",
     )
   end
 
   def test_all
-    assert_equal(6, @theme.all.size)
+    assert_equal(7, @theme.all.size)
   end
 
   def test_assets
@@ -28,7 +29,7 @@ class ThemeTest < Minitest::Test
   end
 
   def test_json
-    assert_equal(1, @theme.json.size)
+    assert_equal(2, @theme.json.size)
     assert(@theme.json.all? { |a| a.instance_of?(ThemeCheck::JsonFile) })
   end
 
@@ -51,11 +52,11 @@ class ThemeTest < Minitest::Test
   end
 
   def test_default_locale_json
-    assert_equal(@theme["locales/en.default"], @theme.default_locale_json)
+    assert_equal(@theme["locales/fr.default"], @theme.default_locale_json)
   end
 
   def test_default_locale
-    assert_equal("en", @theme.default_locale)
+    assert_equal("fr", @theme.default_locale)
   end
 
   def test_ignore


### PR DESCRIPTION
- Fixup the add_translation correction
- Add the remove_translation correction
- Add the LocaleDiff correction for json files
- Ignore locales/*.schema.json files in MatchingTranslations

Fixes #503 