### PR TITLE
Handle rogue carriage returns

### DIFF
--- a/lib/theme_check/checks.rb
+++ b/lib/theme_check/checks.rb
@@ -42,8 +42,7 @@ module ThemeCheck
           check.send(method, *args)
         end
       end
-    rescue Liquid::Error
-      # Pass-through Liquid errors
+    rescue Liquid::Error, ThemeCheckError
       raise
     rescue => e
       node = args.first

--- a/lib/theme_check/html_node.rb
+++ b/lib/theme_check/html_node.rb
@@ -141,6 +141,8 @@ module ThemeCheck
 
     def parseable_markup
       return @parseable_source if @value.name == "#document-fragment"
+      return @value.to_str if @value.comment?
+      return @value.content if literal?
 
       start_index = from_row_column_to_index(@parseable_source, line_number - 1, 0)
       @parseable_source
@@ -163,7 +165,12 @@ module ThemeCheck
 
         Excerpt:
           ```
-          #{@parseable_source.lines[line_number - 1...line_number + 5]}
+          #{@theme_file.source.lines[line_number - 1...line_number + 5].join("")}
+          ```
+
+        Parseable Excerpt:
+          ```
+          #{@parseable_source.lines[line_number - 1...line_number + 5].join("")}
           ```
       MSG
     end

--- a/lib/theme_check/theme_file.rb
+++ b/lib/theme_check/theme_file.rb
@@ -45,7 +45,9 @@ module ThemeCheck
         @source = @storage.read(@relative_path)
       end
       @eol = @source.include?("\r\n") ? "\r\n" : "\n"
-      @source = @source.gsub("\r\n", "\n")
+      @source = @source
+        .gsub(/\r(?!\n)/, "\r\n") # fix rogue \r without followup \n with \r\n
+        .gsub("\r\n", "\n")
     end
 
     def json?

--- a/test/html_node_test.rb
+++ b/test/html_node_test.rb
@@ -36,13 +36,27 @@ module ThemeCheck
       HTML
       root = root_node(html)
       # traversing tree making sure nothing throws
-      find(root) { |node| node.markup != false }
+      find(root) { |node| node.markup == false }
       assert_markup_equals('<div>', root, "div")
       assert_markup_equals('<link rel="stylesheet" href="{{ "styles.css" | asset_url }}">', root, "link")
       assert_markup_equals('<script src="abc.js" defer>', root, "script")
       assert_markup_equals(html[html.index('<img')...html.index('</img>')], root, "img")
       assert_markup_equals(html[html.index('<iframe')...html.index('</iframe>')], root, "iframe")
       assert_markup_equals(html[html.index('<custom-element>')...html.index('</custom-element>')], root, "custom-element")
+    end
+
+    def test_no_freaking_out_on_rogue_carriage_returns
+      html = <<~HTML
+        <div>
+          {{ 'foo.js' | asset_url | stylesheet_tag }}
+          <link rel="stylesheet" href="{{ "styles.css" | asset_url }}">
+          rogue \r character
+          <script src="{ 'foo.js' }" defer></script>
+        </div>
+      HTML
+      root = root_node(html)
+      # traversing tree making sure nothing throws
+      find(root) { |node| node.markup == false }
     end
 
     def test_line_numbers


### PR DESCRIPTION
Turns out that everything blows up when we have \r without a followup \n in a file. Nokogiri will handle it and give you a new line, but we didn't and so we ended up with nokogiri telling you something was on line 61 and us not having the newline character and the thing being on line 60.

Fixes #528
Fixes #545
