### PR TITLE
Prevent bad render tags from passing theme-check

### DIFF
--- a/lib/theme_check/tags.rb
+++ b/lib/theme_check/tags.rb
@@ -125,7 +125,7 @@ module ThemeCheck
     end
 
     class Render < Liquid::Tag
-      SYNTAX = /((?:#{Liquid::QuotedString}|#{Liquid::VariableSegment})+)(\s+(with|#{Liquid::Render::FOR})\s+(#{Liquid::QuotedFragment}+))?(\s+(?:as)\s+(#{Liquid::VariableSegment}+))?/o
+      SYNTAX = /((?:#{Liquid::QuotedString}|\A#{Liquid::VariableSegment})+)(\s+(with|#{Liquid::Render::FOR})\s+(#{Liquid::QuotedFragment}+))?(\s+(?:as)\s+(#{Liquid::VariableSegment}+))?/o
 
       disable_tags "include"
 
@@ -134,7 +134,7 @@ module ThemeCheck
       def initialize(tag_name, markup, options)
         super
 
-        raise SyntaxError, options[:locale].t("errors.syntax.render") unless markup =~ SYNTAX
+        raise Liquid::SyntaxError, options[:locale].t("errors.syntax.render") unless markup =~ SYNTAX
 
         template_name = Regexp.last_match(1)
         with_or_for = Regexp.last_match(3)

--- a/test/checks/syntax_error_test.rb
+++ b/test/checks/syntax_error_test.rb
@@ -41,4 +41,14 @@ class SyntaxErrorTest < Minitest::Test
       Expected end_of_string but found pipe at templates/index.liquid:3
     END
   end
+
+  def test_invalid_render_tag
+    offenses = analyze_theme(
+      ThemeCheck::SyntaxError.new,
+      "templates/index.liquid" => "{% render ‘foo’ %}",
+    )
+    assert_offenses(<<~END, offenses)
+      Syntax error in tag 'render' - Template name must be a quoted string at templates/index.liquid:1
+    END
+  end
 end


### PR DESCRIPTION
The current regex for the liquid tag allows liquid like `{% render ‘foo’ %}` (note the unicode quote characters) to be accepted.

This PR ensures that the render tag in theme-check only accepts valid render tag expressions.

See also https://github.com/Shopify/shopify/issues/329619 (private)