### PR TITLE
Performance Improvements and "themeCheck.onlySingleFileChecks"

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ DeprecateLazysizes:
 - `themeCheck.checkOnOpen` (default: `true`) makes it so theme check runs on file open.
 - `themeCheck.checkOnChange` (default: `true`) makes it so theme check runs on file change.
 - `themeCheck.checkOnSave` (default: `true`) makes it so theme check runs on file save.
+- `themeCheck.onlySingleFileChecks` (default: `false`) makes it so we only check the opened files and disable "whole theme" checks (e.g. UnusedSnippet, TranslationKeyExists)
 
 ⚠️ **Note:** Quickfixes only work on a freshly checked file. If any of those configurations are turned off, you will need to rerun theme-check in order to apply quickfixes.
 

--- a/lib/theme_check/language_server/diagnostic.rb
+++ b/lib/theme_check/language_server/diagnostic.rb
@@ -43,6 +43,10 @@ module ThemeCheck
         offense.single_file?
       end
 
+      def whole_theme?
+        offense.whole_theme?
+      end
+
       def correctable?
         offense.correctable?
       end

--- a/lib/theme_check/language_server/execute_command_providers/run_checks_execute_command_provider.rb
+++ b/lib/theme_check/language_server/execute_command_providers/run_checks_execute_command_provider.rb
@@ -14,7 +14,12 @@ module ThemeCheck
       end
 
       def execute(_args)
-        @diagnostics_engine.analyze_and_send_offenses(@root_path, @root_config, force: true)
+        @diagnostics_engine.analyze_and_send_offenses(
+          @root_path,
+          @root_config,
+          only_single_file: false,
+          force: true
+        )
         nil
       end
     end

--- a/lib/theme_check/language_server/handler.rb
+++ b/lib/theme_check/language_server/handler.rb
@@ -86,7 +86,7 @@ module ThemeCheck
       def on_text_document_did_change(_id, params)
         relative_path = relative_path_from_text_document_uri(params)
         @storage.write(relative_path, content_changes_text(params), text_document_version(params))
-        analyze_and_send_offenses(text_document_uri(params)) if @configuration.check_on_change?
+        analyze_and_send_offenses(text_document_uri(params), only_single_file: true) if @configuration.check_on_change?
       end
 
       def on_text_document_did_close(_id, params)
@@ -190,10 +190,11 @@ module ThemeCheck
         ThemeCheck::Config.from_path(root)
       end
 
-      def analyze_and_send_offenses(absolute_path)
+      def analyze_and_send_offenses(absolute_path, only_single_file: nil)
         @diagnostics_engine.analyze_and_send_offenses(
           absolute_path,
-          config_for_path(absolute_path)
+          config_for_path(absolute_path),
+          only_single_file: only_single_file.nil? ? @configuration.only_single_file? : only_single_file
         )
       end
 

--- a/lib/theme_check/position.rb
+++ b/lib/theme_check/position.rb
@@ -4,6 +4,8 @@ module ThemeCheck
   class Position
     include PositionHelper
 
+    attr_reader :contents
+
     def initialize(
       needle_arg,
       contents_arg,
@@ -12,7 +14,13 @@ module ThemeCheck
       node_markup_offset: 0 # the index of markup inside the node_markup
     )
       @needle = needle_arg
-      @contents = contents_arg
+
+      @contents = if contents_arg&.is_a?(String) && !contents_arg.empty?
+        contents_arg
+      else
+        ''
+      end
+
       @line_number_1_indexed = line_number_1_indexed
       @node_markup_offset = node_markup_offset
       @node_markup = node_markup
@@ -77,18 +85,13 @@ module ThemeCheck
       node_markup_start + @node_markup_offset
     end
 
-    def contents
-      return '' unless @contents.is_a?(String) && !@contents.empty?
-      @contents
-    end
-
     def line_number
       return 0 if @line_number_1_indexed.nil?
       bounded(0, @line_number_1_indexed - 1, content_line_count)
     end
 
     def needle
-      if has_content_and_line_number_but_no_needle?
+      @cached_needle ||= if has_content_and_line_number_but_no_needle?
         entire_line_needle
       elsif contents.empty? || @needle.nil?
         ''

--- a/lib/theme_check/position_helper.rb
+++ b/lib/theme_check/position_helper.rb
@@ -8,11 +8,12 @@ module ThemeCheck
       return 0 unless row.is_a?(Integer) && col.is_a?(Integer)
       i = 0
       safe_row = bounded(0, row, content.count("\n"))
-      scanner = StringScanner.new(content)
-      scanner.scan_until(/\n/) while i < safe_row && (i += 1)
-      result = scanner.charpos || 0
-      scanner.scan_until(/\n|\z/)
-      bounded(result, result + col, scanner.pre_match.size)
+      charpos = -1
+      charpos = content.index("\n", charpos + 1) while i < safe_row && (i += 1) && charpos
+      result = charpos ? charpos + 1 : 0
+      next_line = content.index("\n", result)
+      upper_bound = next_line ? next_line : content.size - 1
+      bounded(result, result + col, upper_bound)
     end
 
     def from_index_to_row_column(content, index)

--- a/test/language_server/diagnostics_engine_test.rb
+++ b/test/language_server/diagnostics_engine_test.rb
@@ -10,11 +10,15 @@ module ThemeCheck
         @messenger = MockMessenger.new
         @bridge = Bridge.new(@messenger)
         @storage = make_file_system_storage(
-          "layout/theme.liquid" => "{% if unclosed %}",
+          "layout/theme.liquid" => "{% render 'a' %}{% render 'b' %}",
           "snippets/a.liquid" => "{% if unclosed %}",
+          "snippets/b.liquid" => "{% if unclosed %}",
+          "snippets/c.liquid" => "",
           ".theme-check.yml" => <<~YML,
             extends: :nothing
             SyntaxError:
+              enabled: true
+            UnusedSnippet:
               enabled: true
           YML
         )
@@ -26,92 +30,176 @@ module ThemeCheck
         analyze_and_send_offenses("layout/theme.liquid")
 
         # Expect diagnostics for all files
-        assert_includes(@messenger.sent_messages, diagnostics_notification("layout/theme.liquid"))
-        assert_includes(@messenger.sent_messages, diagnostics_notification("snippets/a.liquid"))
+        assert_includes(@messenger.sent_messages, diagnostics_notification("snippets/a.liquid", [:syntax]))
+        assert_includes(@messenger.sent_messages, diagnostics_notification("snippets/b.liquid", [:syntax]))
+        assert_includes(@messenger.sent_messages, diagnostics_notification("snippets/c.liquid", [:unused]))
 
         # Secretly correct all the files
-        @storage.write("layout/theme.liquid", "{% if unclosed %}{% endif %}")
         @storage.write("snippets/a.liquid", "{% if unclosed %}{% endif %}")
+        @storage.write("snippets/b.liquid", "{% if unclosed %}{% endif %}")
 
         # Rerun analyze_and_send_offenses on a file
         @messenger.sent_messages.clear
-        analyze_and_send_offenses("layout/theme.liquid")
+        analyze_and_send_offenses("snippets/a.liquid")
 
         # Expect empty diagnostics for the file that was fixed
-        assert_includes(@messenger.sent_messages, empty_diagnostics_notification("layout/theme.liquid"))
-        refute_includes(@messenger.sent_messages, empty_diagnostics_notification("snippets/a.liquid"))
+        assert_includes(@messenger.sent_messages, empty_diagnostics_notification("snippets/a.liquid"))
+        refute_includes(@messenger.sent_messages, empty_diagnostics_notification("snippets/b.liquid"))
 
         # Run it on the other file that was fixed
-        analyze_and_send_offenses("snippets/a.liquid")
+        analyze_and_send_offenses("snippets/b.liquid")
 
         # Expect empty diagnostics for the other file that was fixed
         assert_includes(@messenger.sent_messages, empty_diagnostics_notification("snippets/a.liquid"))
       end
 
-      # If you run analyze_and_send_offenses while one is running, the test should be skipped.
-      def test_analyze_and_send_offenses_is_debounced
-        # Setup test in single file mode
+      def test_analyze_and_send_offenses_with_only_single_file
+        # Only expect single file diagnostics for the file checked
+        analyze_and_send_offenses("snippets/a.liquid", only_single_file: true)
+        assert_includes(@messenger.sent_messages, diagnostics_notification("snippets/a.liquid", [:syntax]))
+        refute_includes(@messenger.sent_messages, diagnostics_notification("snippets/b.liquid", [:syntax]))
+        refute_includes(@messenger.sent_messages, diagnostics_notification("snippets/c.liquid", [:unused]))
+
+        # whole theme checks are ignored in this mode
+        analyze_and_send_offenses("snippets/c.liquid", only_single_file: true)
+        refute_includes(@messenger.sent_messages, diagnostics_notification("snippets/c.liquid", [:unused]))
+
+        # Correct the file
+        @storage.write("snippets/a.liquid", "{% if unclosed %}{% endif %}")
+        @storage.write("snippets/b.liquid", "{% if unclosed %}{% endif %}")
+
+        # Rerun analyze_and_send_offenses on a file
+        @messenger.sent_messages.clear
+        analyze_and_send_offenses("snippets/a.liquid")
+
+        # Expect empty diagnostics for the file that was fixed
+        assert_includes(@messenger.sent_messages, empty_diagnostics_notification("snippets/a.liquid"))
+        refute_includes(@messenger.sent_messages, empty_diagnostics_notification("snippets/b.liquid"))
+        refute_includes(@messenger.sent_messages, empty_diagnostics_notification("snippets/c.liquid"))
+
+        # Run it on the other file that was fixed
+        analyze_and_send_offenses("snippets/b.liquid")
+
+        # Do not expect empty diagnostics for that file, diagnostics were never sent
+        refute_includes(@messenger.sent_messages, empty_diagnostics_notification("snippets/b.liquid"))
+      end
+
+      # For when you want fast checks on change but slow changes on save
+      def test_analyze_and_send_offenses_mixed_mode
+        # Run a full theme check on first run
+        analyze_and_send_offenses("snippets/a.liquid")
+        assert_includes(@messenger.sent_messages, diagnostics_notification("snippets/a.liquid", [:syntax]))
+        assert_includes(@messenger.sent_messages, diagnostics_notification("snippets/b.liquid", [:syntax]))
+        assert_includes(@messenger.sent_messages, diagnostics_notification("snippets/c.liquid", [:unused]))
+
+        # Fix an error by typing code, but only run single file checks
+        @messenger.sent_messages.clear
+        @storage.write("snippets/a.liquid", "{% if unclosed %}{% endif %}")
+        analyze_and_send_offenses("snippets/a.liquid", only_single_file: true)
+
+        # Get updated diagnostics for that file, but not the untouched ones
+        assert_includes(@messenger.sent_messages, empty_diagnostics_notification("snippets/a.liquid"))
+        refute_includes(@messenger.sent_messages, empty_diagnostics_notification("snippets/c.liquid"))
+        refute_includes(@messenger.sent_messages, diagnostics_notification("snippets/c.liquid", [:unused]))
+
+        # Fix the UnusedSnippet error by typing
+        @messenger.sent_messages.clear
+        @storage.write("layout/theme.liquid", "{% render 'a' %}{% render 'b' %}{% render 'c' %}")
+        analyze_and_send_offenses("layout/theme.liquid", only_single_file: true)
+
+        # Don't expect empty or resent diagnostics for the fixed file
+        refute_includes(@messenger.sent_messages, empty_diagnostics_notification("snippets/c.liquid"))
+        refute_includes(@messenger.sent_messages, diagnostics_notification("snippets/c.liquid", [:unused]))
+
+        # Hit "save", run whole theme checks. Remove the fixed offense.
         analyze_and_send_offenses("layout/theme.liquid")
+        assert_includes(@messenger.sent_messages, empty_diagnostics_notification("snippets/c.liquid"))
+      end
+
+      # If you run analyze_and_send_offenses while one is running, the test should be skipped.
+      def test_analyze_and_send_offenses_is_throttled
+        # Setup test in single file mode
+        analyze_and_send_offenses("snippets/a.liquid")
         @messenger.sent_messages.clear
 
         threads = []
         10.times do
           threads << Thread.new do
-            analyze_and_send_offenses("layout/theme.liquid")
+            analyze_and_send_offenses("snippets/a.liquid")
           end
         end
         threads.each { |t| t.join if t.alive? }
         assert(@messenger.sent_messages.size < threads.size)
       end
 
-      def analyze_and_send_offenses(path)
-        @engine.analyze_and_send_offenses(@storage.path(path), ThemeCheck::Config.from_path(@storage.root))
+      def analyze_and_send_offenses(path, only_single_file: false)
+        @engine.analyze_and_send_offenses(
+          @storage.path(path),
+          ThemeCheck::Config.from_path(@storage.root),
+          only_single_file: only_single_file
+        )
       end
 
-      def diagnostics_notification(path)
+      def diagnostics_notification(path, error_types)
+        diagnostics = []
+        diagnostics << unused_snippet(path) if error_types.include?(:unused)
+        diagnostics << syntax_error(path) if error_types.include?(:syntax)
         {
           jsonrpc: "2.0",
           method: "textDocument/publishDiagnostics",
           params: {
             uri: file_uri(@storage.path(path)),
-            diagnostics: expected_diagnostics(path),
+            diagnostics: diagnostics,
           },
         }
       end
 
       def empty_diagnostics_notification(path)
+        diagnostics_notification(path, [])
+      end
+
+      def unused_snippet(path)
         {
-          jsonrpc: "2.0",
-          method: "textDocument/publishDiagnostics",
-          params: {
+          code: "UnusedSnippet",
+          message: "This snippet is not used",
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+          severity: 2,
+          source: "theme-check",
+          codeDescription: {
+            href: "https://github.com/Shopify/theme-check/blob/main/docs/checks/unused_snippet.md",
+          },
+          data: {
             uri: file_uri(@storage.path(path)),
-            diagnostics: [],
+            absolute_path: @storage.path(path).to_s,
+            relative_path: path.to_s,
+            version: nil,
           },
         }
       end
 
-      def expected_diagnostics(path)
-        [
-          {
-            code: "SyntaxError",
-            message: "'if' tag was never closed",
-            range: {
-              start: { line: 0, character: 0 },
-              end: { line: 0, character: 16 },
-            },
-            severity: 1,
-            source: "theme-check",
-            codeDescription: {
-              href: "https://github.com/Shopify/theme-check/blob/main/docs/checks/syntax_error.md",
-            },
-            data: {
-              uri: file_uri(@storage.path(path)),
-              absolute_path: @storage.path(path).to_s,
-              relative_path: path.to_s,
-              version: nil,
-            },
+      def syntax_error(path)
+        {
+          code: "SyntaxError",
+          message: "'if' tag was never closed",
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 16 },
           },
-        ]
+          severity: 1,
+          source: "theme-check",
+          codeDescription: {
+            href: "https://github.com/Shopify/theme-check/blob/main/docs/checks/syntax_error.md",
+          },
+          data: {
+            uri: file_uri(@storage.path(path)),
+            absolute_path: @storage.path(path).to_s,
+            relative_path: path.to_s,
+            version: nil,
+          },
+        }
       end
     end
   end


### PR DESCRIPTION
- Speed up partial theme checks & add `"themeCheck.onlySingleFileChecks"`

  The difference here is that instead of rerunning all the whole theme checks on change, as we previously did, we only do that on save and open when `"themeCheck.onlySingleFileChecks"` is true. What this means is that whenever you are typing, only the single file checks will run.

  This takes ~10ms on my M1 MBP. Not the best machine to do benchmarks on but it's 125x faster than what we had before. So I'm assuming that this 100x+ improvement will transfer to slower machines as well :D

  When `"themeCheck.onlySingleFileChecks"` is true, then we disable all whole theme checks entirely and only report failures for the open files. This means that it will always be fast, but it comes at the cost of not having MissingTranslations, UnusedSnippet, and other checks that span multiple files.

  Fixes #542
  Fixes #507

- Improve performance of from_row_column_to_index
  
  Make it do twice as many iterations per second (according to benchmark/ips) than the previous implementation.

- Save hundreds of thousands of calls by caching some methods


### Before

https://user-images.githubusercontent.com/4990691/155556285-a0490562-d59e-48f8-ad7f-fe7cf2ac759c.mp4

### After

- `"themeCheck.onlySingleFileChecks": false

  https://user-images.githubusercontent.com/4990691/155549947-3274d4b0-ee8a-4fc5-a76c-584a014055d3.mp4

- `"themeCheck.onlySingleFileChecks": true

   https://user-images.githubusercontent.com/4990691/155550962-a1b0dd41-de3e-4912-b836-b0c7d35655d5.mp4

