### PR TITLE
Prevent bad render tags from passing theme-check

### DIFF
--- a/test/checks/syntax_error_test.rb
+++ b/test/checks/syntax_error_test.rb
@@ -41,4 +41,14 @@ class SyntaxErrorTest < Minitest::Test
       Expected end_of_string but found pipe at templates/index.liquid:3
     END
   end
+
+  def test_invalid_render_tag
+    offenses = analyze_theme(
+      ThemeCheck::SyntaxError.new,
+      "templates/index.liquid" => "{% render ‘foo’ %}",
+    )
+    assert_offenses(<<~END, offenses)
+      Syntax error in tag 'render' - Template name must be a quoted string at templates/index.liquid:1
+    END
+  end
 end

--- a/test/checks/undefined_object_test.rb
+++ b/test/checks/undefined_object_test.rb
@@ -387,4 +387,12 @@ class UndefinedObjectTest < Minitest::Test
       Missing argument `some_end_condition` at snippets/one.liquid:1
     END
   end
+
+  def test_render_block
+    offenses = analyze_theme(
+      ThemeCheck::UndefinedObject.new(exclude_snippets: false),
+      "sections/apps.liquid" => "{% render block %}"
+    )
+    assert_offenses("", offenses)
+  end
 end


### PR DESCRIPTION
Follow up to #551. This time with tests to make sure it doesn't break!

I fixed the regex, with what we want to land in core.

I also tested it against Dawn 3.0.0, and it didn't raise any undefined object errors.