### PR TITLE
Fix requiring custom check when root is specified

### DIFF
--- a/lib/theme_check/config.rb
+++ b/lib/theme_check/config.rb
@@ -209,7 +209,8 @@ module ThemeCheck
 
     def resolve_requires
       self["require"]&.each do |path|
-        require(File.join(@root, path))
+        file_to_require = @root.join(path).realpath
+        require(file_to_require.to_s)
       end
     end
   end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -277,6 +277,31 @@ class ConfigTest < Minitest::Test
     assert(check_enabled?(config, ThemeCheck::CustomCheck))
   end
 
+  def test_custom_check_with_root
+    storage = make_file_system_storage(
+      ".theme-check.yml" => <<~END,
+        root: dist
+        include_categories: []
+        require:
+          - ../checks/custom_check.rb
+        CustomCheck:
+          enabled: true
+      END
+      "dist/layout/theme.liquid" => <<~END,
+        <html>
+        </html>
+        END
+      "checks/custom_check.rb" => <<~END,
+        module ThemeCheck
+          class CustomCheck < Check
+          end
+        end
+        END
+    )
+    config = ThemeCheck::Config.from_path(storage.root)
+    assert(check_enabled?(config, ThemeCheck::CustomCheck))
+  end
+
   def test_include_category
     config = ThemeCheck::Config.new(root: ".")
     config.include_categories = [:liquid]

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -279,7 +279,7 @@ class ConfigTest < Minitest::Test
 
   def test_custom_check_with_root
     storage = make_file_system_storage(
-      ".theme-check.yml" => <<~END,
+      ".config/.theme-check.yml" => <<~END,
         root: dist
         include_categories: []
         require:
@@ -287,10 +287,7 @@ class ConfigTest < Minitest::Test
         CustomCheck:
           enabled: true
       END
-      "dist/layout/theme.liquid" => <<~END,
-        <html>
-        </html>
-        END
+      "dist/layout/theme.liquid" => "",
       "checks/custom_check.rb" => <<~END,
         module ThemeCheck
           class CustomCheck < Check
@@ -298,7 +295,12 @@ class ConfigTest < Minitest::Test
         end
         END
     )
-    config = ThemeCheck::Config.from_path(storage.root)
+
+    config = ThemeCheck::Config.new(
+      root: storage.root,
+      configuration: ThemeCheck::Config.load_config(storage.root.join('.config/.theme-check.yml'))
+    )
+
     assert(check_enabled?(config, ThemeCheck::CustomCheck))
   end
 


### PR DESCRIPTION
Potential fix for #564 

# Basic issue
I'm running `theme check` for a root `dist` and trying to require a custom check that lives outside the `dist` folder

# Notes:
- The spec I wrote doesn't break either way, I believe because when run from command line like `shopify theme check --config .config/.theme-check.yml` then `ThemeCheck::Config.load_config` gets a relative path passed in and I'm not 100% sure how to simulate that with the spec
