### PR TITLE
Fix unknown configuration issue for UndefinedObject checker

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -101,6 +101,7 @@ UndefinedObject:
   enabled: true
   ignore: []
   exclude_snippets: true
+  config_type: :default
 
 RequiredDirectories:
   enabled: true

--- a/config/theme_app_extension.yml
+++ b/config/theme_app_extension.yml
@@ -89,7 +89,7 @@ UndefinedObject:
   enabled: true
   ignore: []
   exclude_snippets: true
-  config_type: theme_app_extension
+  config_type: :theme_app_extension
 
 RequiredDirectories:
   enabled: false


### PR DESCRIPTION
Fix for https://github.com/Shopify/theme-check/pull/566

We introduced a new arg for UndefinedObject checker without providing a default value for this arg/configuration in `default.yml`. This cause theme-check to report warning: `unknown configuration: UndefinedObject.config_type`

We added this configuration in `default.yml` config file and fixed the values of these configs to a proper `symbol` format in the yml file