### PR TITLE
Fix TranslationKeyExists.on_end issue

### DIFF
--- a/lib/theme_check/checks/translation_key_exists.rb
+++ b/lib/theme_check/checks/translation_key_exists.rb
@@ -48,6 +48,7 @@ module ThemeCheck
 
     def key_exists?(key, pointer)
       key.split(".").each do |token|
+        return false unless pointer.is_a?(Hash)
         return false unless pointer.key?(token)
         pointer = pointer[token]
       end

--- a/test/checks/translation_key_exists_test.rb
+++ b/test/checks/translation_key_exists_test.rb
@@ -148,4 +148,22 @@ class TranslationKeyExistsTest < Minitest::Test
 
     assert_equal(expected, actual)
   end
+
+  def test_handles_key_conflicts
+    theme = make_theme(
+      "locales/en.default.json" => JSON.dump({
+        product: { quantity: "TODO" },
+      }),
+      "templates/index.liquid" => <<~END,
+        {{"product.quantity.decrease" | t}}
+      END
+    )
+
+    analyzer = ThemeCheck::Analyzer.new(theme, [ThemeCheck::TranslationKeyExists.new], true)
+    analyzer.analyze_theme
+
+    assert_offenses(<<~END, analyzer.offenses)
+      'product.quantity.decrease' does not have a matching entry in 'locales/en.default.json' at templates/index.liquid:1
+    END
+  end
 end


### PR DESCRIPTION
We had a bug if the key path existed but "ended" early.

Fixes #571
