### PR TITLE
Fix IndexError: string not matched in matching translation keys fixer

### DIFF
--- a/lib/theme_check/schema_helper.rb
+++ b/lib/theme_check/schema_helper.rb
@@ -8,7 +8,7 @@ module ThemeCheck
       path.each_with_index.reduce(hash) do |pointer, (token, index)|
         if index == path.size - 1
           pointer[token] = value
-        elsif !pointer.key?(token)
+        elsif !pointer.key?(token) || !pointer[token].is_a?(Hash)
           pointer[token] = {}
         end
         pointer[token]

--- a/test/checks/matching_translations_test.rb
+++ b/test/checks/matching_translations_test.rb
@@ -195,4 +195,36 @@ class MatchingTranslationsTest < Minitest::Test
 
     assert_offenses("", offenses)
   end
+
+  def test_shape_change
+    sources = fix_theme(
+      ThemeCheck::MatchingTranslations.new,
+      "locales/en.default.json" => JSON.dump(
+        hello: {
+          another_key: "world",
+          shape_change: "world",
+        },
+      ),
+      "locales/fr.json" => JSON.dump(
+        hello: "Bonjour",
+      ),
+    )
+    expected_sources = {
+      "locales/en.default.json" => JSON.dump(
+        hello: {
+          another_key: "world",
+          shape_change: "world",
+        },
+      ),
+      "locales/fr.json" => JSON.dump(
+        hello: {
+          another_key: "TODO",
+          shape_change: "TODO",
+        },
+      ),
+    }
+    sources.each do |path, source|
+      assert_equal(expected_sources[path], source)
+    end
+  end
 end

--- a/test/schema_helper_test.rb
+++ b/test/schema_helper_test.rb
@@ -7,6 +7,9 @@ module ThemeCheck
       assert_equal({ "a" => { "b" => 1 } }, SchemaHelper.set({}, 'a.b', 1))
       assert_equal({ "a" => { "b" => 1 } }, SchemaHelper.set({}, ['a', 'b'], 1))
       assert_equal({ "a" => { "b" => 1 } }, SchemaHelper.set({ "a" => { "b" => 0 } }, 'a.b', 1))
+      assert_equal({ "a" => { "1" => "str" } }, SchemaHelper.set({ "a" => "b" }, 'a.1', "str"))
+      assert_equal({ "a" => { "b" => "str" } }, SchemaHelper.set({ "a" => "b" }, 'a.b', "str"))
+      assert_equal({ "a" => 1 }, SchemaHelper.set({ "a" => { "b" => 1 } }, 'a', 1))
     end
 
     def test_delete


### PR DESCRIPTION
Fixes #585

The IndexError happened when MatchingTranslation fixer tried to change the shape of a translation (from string to Hash)

e.g.

```
{
  "parent" => "child translation"
}
=>
{
  "parent" => {
    "child1": "TODO"
    "child2": "TODO"
  }
}
```

The fix is to make sure that the child is Hash if you are setting a value.
