### PR TITLE
Fix UnusedAssign false positives from `{% render ... with var %}`

### DIFF
--- a/lib/theme_check/tags.rb
+++ b/lib/theme_check/tags.rb
@@ -145,7 +145,7 @@ module ThemeCheck
 
       disable_tags "include"
 
-      attr_reader :template_name_expr, :attributes
+      attr_reader :template_name_expr, :variable_name_expr, :attributes
 
       def initialize(tag_name, markup, options)
         super
@@ -171,6 +171,7 @@ module ThemeCheck
         def children
           [
             @node.template_name_expr,
+            @node.variable_name_expr,
           ] + @node.attributes.values
         end
       end

--- a/test/checks/unused_assign_test.rb
+++ b/test/checks/unused_assign_test.rb
@@ -24,6 +24,8 @@ class UnusedAssignTest < Minitest::Test
         {{ 'a' | t: b }}
         {% assign c = 1 %}
         {{ 'a' | t: tags: c }}
+        {% assign d = 1 %}
+        {% render 'foo' with d %}
       END
     )
     assert_offenses("", offenses)

--- a/test/liquid_visitor_test.rb
+++ b/test/liquid_visitor_test.rb
@@ -114,6 +114,54 @@ class LiquidVisitorTest < Minitest::Test
     ], @tracer.calls)
   end
 
+  def test_render
+    theme_file = parse_liquid(<<~END)
+      {% for block in section.blocks %}
+        {% assign x = 1 %}
+        {% render block with x %}
+      {% endfor %}
+    END
+    @visitor.visit_liquid_file(theme_file)
+    assert_equal([
+      :on_document,
+      :on_tag,
+      :on_for,
+      :on_block_body,
+      :on_string,
+      "\n" + "  ",
+      :on_tag,
+      :on_assign,
+      :on_variable,
+      :on_integer,
+      1,
+      :after_variable,
+      :after_assign,
+      :after_tag,
+      :on_string,
+      "\n" + "  ",
+      :on_tag,
+      :on_render,
+      :on_variable_lookup,
+      :after_variable_lookup,
+      :on_variable_lookup,
+      :after_variable_lookup,
+      :after_render,
+      :after_tag,
+      :on_string,
+      "\n",
+      :after_block_body,
+      :on_variable_lookup,
+      :on_string,
+      "blocks",
+      :after_variable_lookup,
+      :after_for,
+      :after_tag,
+      :on_string,
+      "\n",
+      :after_document,
+    ], @tracer.calls)
+  end
+
   def test_form
     theme_file = parse_liquid(<<~END)
       {% form 'type', object, key: value %}


### PR DESCRIPTION
Fixes #582

Echo of https://github.com/Shopify/liquid/pull/1596 in our SFR port.