### PR TITLE
Bump min version of ruby to 2.7

### DIFF
--- a/.github/workflows/theme-check.yml
+++ b/.github/workflows/theme-check.yml
@@ -13,7 +13,7 @@ jobs:
           - windows-latest
         version:
           - 3.0.0
-          - 2.6.6
+          - 2.7.6
         theme:
           - Shopify/dawn
 

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: theme-check
 type: ruby
 
 up:
-  - ruby: 2.6.6
+  - ruby: "2.7"
   - bundler
 
 commands:

--- a/theme-check.gemspec
+++ b/theme-check.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/Shopify/theme-check"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 


### PR DESCRIPTION
Shopify/liquid has dropped support for 2.6 (who is now EOL), we are forced
to do the same.

https://github.com/Shopify/liquid/blob/master/History.md#breaking-changes
