### PR TITLE
Handle variable lookup as names in UnusedAssign

### DIFF
--- a/lib/theme_check/checks/unused_assign.rb
+++ b/lib/theme_check/checks/unused_assign.rb
@@ -39,7 +39,12 @@ module ThemeCheck
     end
 
     def on_variable_lookup(node)
-      @templates[node.theme_file.name].used_assigns << node.value.name
+      @templates[node.theme_file.name].used_assigns << case node.value.name
+      when Liquid::VariableLookup
+        node.value.name.name
+      else
+        node.value.name
+      end
     end
 
     def on_end

--- a/test/checks/unused_assign_test.rb
+++ b/test/checks/unused_assign_test.rb
@@ -31,6 +31,20 @@ class UnusedAssignTest < Minitest::Test
     assert_offenses("", offenses)
   end
 
+  def test_do_not_report_used_assigns_bracket_syntax
+    offenses = analyze_theme(
+      ThemeCheck::UnusedAssign.new,
+      "templates/index.liquid" => <<~END,
+        {% liquid
+          assign resource = request.page_type
+          assign meta_value = [resource].metafields.namespace.key
+          echo meta_value
+        %}
+      END
+    )
+    assert_offenses("", offenses)
+  end
+
   def test_do_not_report_assigns_used_before_defined
     offenses = analyze_theme(
       ThemeCheck::UnusedAssign.new,


### PR DESCRIPTION
The `{{ [some_var] }}` syntax is valid Liquid. When this happens, the
tree gives us a Liquid::VariableLookup for the node.value.name (instead
of a string).

To handle those cases, we simply return node.value.name.name.

It's not entirely future proof, but fixing this in Shopify/liquid seemed non-trivial.

Fixes #576
