### PR TITLE
Fix MissingTemplate `ignore` config interactions

### DIFF
--- a/lib/theme_check/check.rb
+++ b/lib/theme_check/check.rb
@@ -6,7 +6,8 @@ module ThemeCheck
     include JsonHelpers
 
     attr_accessor :theme
-    attr_accessor :options, :ignored_patterns
+    attr_accessor :options
+    attr_writer :ignored_patterns
     attr_writer :offenses
 
     # The order matters.
@@ -128,6 +129,10 @@ module ThemeCheck
 
     def ignored?
       defined?(@ignored) && @ignored
+    end
+
+    def ignored_patterns
+      @ignored_patterns ||= []
     end
 
     def can_disable?

--- a/lib/theme_check/checks/missing_template.rb
+++ b/lib/theme_check/checks/missing_template.rb
@@ -28,7 +28,11 @@ module ThemeCheck
     private
 
     def ignore?(path)
-      @ignore_missing.any? { |pattern| File.fnmatch?(pattern, path) }
+      all_ignored_patterns.any? { |pattern| File.fnmatch?(pattern, path) }
+    end
+
+    def all_ignored_patterns
+      @all_ignored_patterns ||= @ignore_missing + ignored_patterns
     end
 
     def add_missing_offense(name, node:)

--- a/lib/theme_check/config.rb
+++ b/lib/theme_check/config.rb
@@ -126,14 +126,14 @@ module ThemeCheck
         options_for_check = options.transform_keys(&:to_sym)
         options_for_check.delete(:enabled)
         severity = options_for_check.delete(:severity)
-        ignored_patterns = options_for_check.delete(:ignore) || []
+        check_ignored_patterns = options_for_check.delete(:ignore) || []
         check = if options_for_check.empty?
           check_class.new
         else
           check_class.new(**options_for_check)
         end
         check.severity = severity.to_sym if severity
-        check.ignored_patterns = ignored_patterns
+        check.ignored_patterns = check_ignored_patterns + ignored_patterns
         check.options = options_for_check
         check
       end.compact

--- a/lib/theme_check/disabled_checks.rb
+++ b/lib/theme_check/disabled_checks.rb
@@ -41,7 +41,7 @@ module ThemeCheck
 
     def disabled?(check, theme_file, check_name, index)
       return true if check.ignored_patterns&.any? do |pattern|
-        theme_file.relative_path.fnmatch?(pattern)
+        theme_file&.relative_path&.fnmatch?(pattern)
       end
 
       @disabled_checks[[theme_file, :all]]&.disabled?(index) ||

--- a/test/checks/missing_template_test.rb
+++ b/test/checks/missing_template_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "test_helper"
 
 class MissingTemplateTest < Minitest::Test
@@ -69,6 +70,29 @@ class MissingTemplateTest < Minitest::Test
         {% section 'anything' %}
       END
     )
+    assert_offenses("", offenses)
+  end
+
+  # Slightly different config, if you top-level ignore all snippets/icon-*,
+  # then you should probably also ignore missing templates of all snippets/icon-*
+  # See #489 or #589 for more context.
+  def test_ignore_config
+    check = ThemeCheck::MissingTemplate.new
+
+    # this is what config.rb would do
+    check.ignored_patterns = [
+      "snippets/icon-*",
+      "sections/*",
+    ]
+
+    offenses = analyze_theme(
+      check,
+      "templates/index.liquid" => <<~END,
+        {% render 'icon-nope' %}
+        {% section 'anything' %}
+      END
+    )
+
     assert_offenses("", offenses)
   end
 


### PR DESCRIPTION
Fixes #589
Fixes #489

Approach used:
If you're ignoring a file, then we shouldn't be able to flag it as missing. Global and check `ignore` configs are merged with the `ignore_missing` config for the check. 