### PR TITLE
Fix MissingRequiredTemplateFiles JSON file corrector

### DIFF
--- a/lib/theme_check/checks/missing_required_template_files.rb
+++ b/lib/theme_check/checks/missing_required_template_files.rb
@@ -33,7 +33,11 @@ module ThemeCheck
           if REQUIRED_LIQUID_TEMPLATE_FILES.include?(file)
             corrector.create_file(@theme.storage, "#{file}.liquid", "")
           else
-            corrector.create_file(@theme.storage, "#{file}.json", "")
+            corrector.create_file(@theme.storage, "#{file}.json", JSON.pretty_generate({
+              name: "TODO",
+              sections: {},
+              order: [],
+            }))
           end
         end
       end


### PR DESCRIPTION
The file should at least contain an object with meaningufl key/values.

Fixes #578
