### PR TITLE
Fixes theme-check-disable when disable comment is followed by another

### DIFF
--- a/lib/theme_check/disabled_checks.rb
+++ b/lib/theme_check/disabled_checks.rb
@@ -34,8 +34,10 @@ module ThemeCheck
         # We want to disable checks inside comments
         # (e.g. html checks inside {% comment %})
         disabled = @disabled_checks[[node.theme_file, :all]]
-        disabled.start_index = node.inner_markup_start_index
-        disabled.end_index = node.inner_markup_end_index
+        unless disabled.first_line
+          disabled.start_index = node.inner_markup_start_index
+          disabled.end_index = node.inner_markup_end_index
+        end
       end
     end
 

--- a/test/disabled_checks_test.rb
+++ b/test/disabled_checks_test.rb
@@ -67,6 +67,24 @@ module ThemeCheck
       assert_empty(@regex_check.offenses)
     end
 
+    def test_ignore_all_checks_issue_583
+      liquid_file = parse_liquid(<<~END)
+        {% comment %}theme-check-disable{% endcomment %}
+        {% comment %}
+          This is some comment about the file...
+          Adding a comment here should not mess with theme-check-disable
+        {% endcomment %}
+        {% assign x = 'x' %}
+        RegexError 1
+        {% comment %}theme-check-enable{% endcomment %}
+      END
+      @visitor.visit_liquid_file(liquid_file)
+      @disabled_checks.remove_disabled_offenses(@checks)
+
+      assert_empty(@assign_check.offenses)
+      assert_empty(@regex_check.offenses)
+    end
+
     def test_ignore_all_checks_without_end
       liquid_file = parse_liquid(<<~END)
         {% comment %}theme-check-disable{% endcomment %}


### PR DESCRIPTION
Kind of weird edge case. If the theme-check-disable (:all) comment was followed
by another comment, then the theme-check-disable (:all) comment was made to only
apply on the range of the followup comment.

The fix is to not do that when theme-check-disable :all is meant to be
applied to the entire document.

Fixes #583
