### PR TITLE
Make runChecks command respect onlySingleFileChecks

### DIFF
--- a/lib/theme_check/language_server/diagnostics_engine.rb
+++ b/lib/theme_check/language_server/diagnostics_engine.rb
@@ -24,7 +24,7 @@ module ThemeCheck
         theme = ThemeCheck::Theme.new(storage)
         analyzer = ThemeCheck::Analyzer.new(theme, config.enabled_checks)
 
-        if (!only_single_file && @diagnostics_manager.first_run?) || force
+        if !only_single_file && (@diagnostics_manager.first_run? || force)
           run_full_theme_check(analyzer)
         else
           run_partial_theme_check(absolute_path_or_paths, theme, analyzer, only_single_file)

--- a/lib/theme_check/language_server/execute_command_providers/run_checks_execute_command_provider.rb
+++ b/lib/theme_check/language_server/execute_command_providers/run_checks_execute_command_provider.rb
@@ -7,17 +7,18 @@ module ThemeCheck
 
       command "runChecks"
 
-      def initialize(diagnostics_engine, root_path, root_config)
+      def initialize(diagnostics_engine, storage, linter_config, language_server_config)
         @diagnostics_engine = diagnostics_engine
-        @root_path = root_path
-        @root_config = root_config
+        @storage = storage
+        @linter_config = linter_config
+        @language_server_config = language_server_config
       end
 
       def execute(_args)
         @diagnostics_engine.analyze_and_send_offenses(
-          @root_path,
-          @root_config,
-          only_single_file: false,
+          @storage.opened_files.map { |relative_path| @storage.path(relative_path) },
+          @linter_config,
+          only_single_file: @language_server_config.only_single_file?,
           force: true
         )
         nil

--- a/lib/theme_check/language_server/handler.rb
+++ b/lib/theme_check/language_server/handler.rb
@@ -72,7 +72,12 @@ module ThemeCheck
         @diagnostics_engine = DiagnosticsEngine.new(@storage, @bridge, @diagnostics_manager)
         @execute_command_engine = ExecuteCommandEngine.new
         @execute_command_engine << CorrectionExecuteCommandProvider.new(@storage, @bridge, @diagnostics_manager)
-        @execute_command_engine << RunChecksExecuteCommandProvider.new(@diagnostics_engine, @root_path, config_for_path(@root_path))
+        @execute_command_engine << RunChecksExecuteCommandProvider.new(
+          @diagnostics_engine,
+          @storage,
+          config_for_path(@root_path),
+          @configuration,
+        )
         @code_action_engine = CodeActionEngine.new(@storage, @diagnostics_manager)
         @bridge.send_response(id, {
           capabilities: CAPABILITIES,

--- a/lib/theme_check/language_server/versioned_in_memory_storage.rb
+++ b/lib/theme_check/language_server/versioned_in_memory_storage.rb
@@ -8,7 +8,7 @@ module ThemeCheck
 
     def initialize(files, root = "/dev/null")
       super(files, root)
-      @versions = {}
+      @versions = {} # Hash<relative_path, number>
       @mutex = Mutex.new
     end
 
@@ -49,7 +49,11 @@ module ThemeCheck
     #   - Only offer fixes on "clean" files (or offer the change but specify the version so the editor knows what to do with it)
     def write(relative_path, content, version)
       @mutex.synchronize do
-        @versions[relative_path] = version
+        if version.nil?
+          @versions.delete(relative_path)
+        else
+          @versions[relative_path] = version
+        end
         super(relative_path, content)
       end
     end
@@ -71,6 +75,10 @@ module ThemeCheck
 
     def version(relative_path)
       @versions[relative_path.to_s]
+    end
+
+    def opened_files
+      @versions.keys
     end
   end
 end


### PR DESCRIPTION
Logic was wrong.

When onlySingleFileChecks is on and someone executes the `runChecks`
command. We should do the following:

- Run checks for opened files
- Update diagnostics from opened files
- Do not show "whole theme checks"

Fixes #570
