### PR TITLE
Fix: IndexError: string not matched

### DIFF
--- a/lib/theme_check/schema_helper.rb
+++ b/lib/theme_check/schema_helper.rb
@@ -6,9 +6,11 @@ module ThemeCheck
     def self.set(hash, path, value)
       path = path.split('.') if path.is_a?(String)
       path.each_with_index.reduce(hash) do |pointer, (token, index)|
-        if index == path.size - 1
+        if index == path.size - 1 # Last element
           pointer[token] = value
-        elsif !pointer.key?(token) || !pointer[token].is_a?(Hash)
+        elsif !pointer.key?(token) # Parent (pointer) does not a value for token
+          pointer[token] = {}
+        elsif !pointer[token].is_a?(Hash) # Parent's (pointer) value for token is not a Hash, for example: String
           pointer[token] = {}
         end
         pointer[token]

--- a/test/schema_helper_test.rb
+++ b/test/schema_helper_test.rb
@@ -10,6 +10,7 @@ module ThemeCheck
       assert_equal({ "a" => { "1" => "str" } }, SchemaHelper.set({ "a" => "b" }, 'a.1', "str"))
       assert_equal({ "a" => { "b" => "str" } }, SchemaHelper.set({ "a" => "b" }, 'a.b', "str"))
       assert_equal({ "a" => 1 }, SchemaHelper.set({ "a" => { "b" => 1 } }, 'a', 1))
+      assert_equal({ "a" => { "b" => "str" } }, SchemaHelper.set({ "a" => "foo" }, "a.b", "str"))
     end
 
     def test_delete


### PR DESCRIPTION
Issue: A settings file, for example `{foo: "bar"}` could exist. It could be missing a property "foo.baz". The checker will attempt to write `{foo: {baz: "TODO"}}`. However, the write will fail because the value of "foo" is not a Hash but a String.
The simplest solution is to re-write the value of "foo" to be a Hash `{foo: {}}` and then write the rest of the nested value (in this case, `{baz: "TODO"}`).

Caution: This could be lossy. However, I believe that the assumption is that source control is in place already.