### PR TITLE
robots Object in robots.txt file

### DIFF
--- a/lib/theme_check/checks/undefined_object.rb
+++ b/lib/theme_check/checks/undefined_object.rb
@@ -120,6 +120,10 @@ module ThemeCheck
           # NOTE: `email` is exceptionally exposed as a theme object in
           #       the customers' reset password template
           check_object(info, all_global_objects + ['email'])
+        elsif 'templates/robots.txt' == name
+          # NOTE: `robots` is the only object exposed object in
+          #       the robots.txt template
+          check_object(info, ['robots'])
         elsif 'layout/checkout' == name
           # NOTE: Shopify Plus has exceptionally exposed objects in
           #       the checkout template

--- a/test/checks/undefined_object_test.rb
+++ b/test/checks/undefined_object_test.rb
@@ -334,6 +334,48 @@ class UndefinedObjectTest < Minitest::Test
     END
   end
 
+  def test_does_not_report_on_robots_in_robots
+    offenses = analyze_theme(
+      ThemeCheck::UndefinedObject.new(exclude_snippets: false),
+      "templates/robots.txt.liquid" => <<~END,
+        {% for group in robots.default_groups %}
+          {{- group.user_agent -}}
+
+          {% for rule in group.rules %}
+            {{- rule -}}
+          {% endfor %}
+
+          {%- if group.sitemap != blank -%}
+            {{ group.sitemap }}
+          {%- endif -%}
+        {% endfor %}
+      END
+    )
+    assert_offenses("", offenses)
+  end
+
+  def test_reports_on_robots_other_than_robots
+    offenses = analyze_theme(
+      ThemeCheck::UndefinedObject.new(exclude_snippets: false),
+      "templates/index.liquid" => <<~END,
+        {% for group in robots.default_groups %}
+          {{- group.user_agent -}}
+
+          {% for rule in group.rules %}
+            {{- rule -}}
+          {% endfor %}
+
+          {%- if group.sitemap != blank -%}
+            {{ group.sitemap }}
+          {%- endif -%}
+        {% endfor %}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Undefined object `robots` at templates/index.liquid:1
+    END
+  end
+
   def test_does_not_report_on_shopify_plus_objects_in_checkout
     offenses = analyze_theme(
       ThemeCheck::UndefinedObject.new(exclude_snippets: false),


### PR DESCRIPTION
This PR adds the robots object as „global“ object for the UndefinedObject check. It just adds this for the robots.txt and should through an offense in all other templates.