### PR TITLE
Download theme-liquid-docs on package deploy or while running theme-check

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,6 +53,13 @@ task :prerelease, [:version] do |_t, args|
   ThemeCheck::Releaser.new.release(args.version)
 end
 
+desc("Download theme-liquid-docs")
+task :download_theme_liquid_docs do
+  require 'theme_check/shopify_liquid/source_manager'
+
+  ThemeCheck::ShopifyLiquid::SourceManager.download
+end
+
 desc "Create a new check"
 task :new_check, [:name] do |_t, args|
   require "theme_check/string_helpers"

--- a/lib/theme_check/shopify_liquid/source_manager.rb
+++ b/lib/theme_check/shopify_liquid/source_manager.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'pathname'
+
+module ThemeCheck
+  module ShopifyLiquid
+    module SourceManager
+      extend self
+
+      def download_or_refresh_files
+        if has_required_files?
+          # TODO: https://github.com/Shopify/theme-check/issues/651
+          #
+          # Refresh files if they exist locally
+        else
+          download
+        end
+      end
+
+      def download
+        create_destination unless destination_exist?
+
+        required_file_names.each do |file_name|
+          download_file(local_path(file_name), remote_path(file_name))
+        end
+      end
+
+      def local_path(file_name)
+        documentation_directory + "#{file_name}.json"
+      end
+
+      private
+
+      DOCUMENTATION_FETCH_URL = "https://github.com/Shopify/theme-liquid-docs/raw/main/data"
+      DOCUMENTATION_DIRECTORY = Pathname.new("#{__dir__}/../../../data/shopify_liquid/documentation")
+      REQUIRED_FILE_NAMES = [:filters, :objects, :tags].freeze
+
+      def remote_path(file_name)
+        "#{documentation_fetch_url}/#{file_name}.json"
+      end
+
+      def download_file(local, remote)
+        File.open(local, "wb") do |file|
+          content = open_uri(remote)
+
+          file.write(content)
+        end
+      end
+
+      def open_uri(remote)
+        # require at usage point to not slow down theme-check on startup
+        require 'open-uri'
+
+        URI.parse(remote).open.read
+      end
+
+      def destination_exist?
+        documentation_directory.exist?
+      end
+
+      def create_destination
+        Dir.mkdir(documentation_directory)
+      end
+
+      def documentation_directory
+        DOCUMENTATION_DIRECTORY
+      end
+
+      def documentation_fetch_url
+        DOCUMENTATION_FETCH_URL
+      end
+
+      def required_file_names
+        REQUIRED_FILE_NAMES
+      end
+
+      def has_required_files?
+        required_file_names.all? { |file_name| local_path(file_name).exist? }
+      end
+    end
+  end
+end

--- a/shipit.rubygems.yml
+++ b/shipit.rubygems.yml
@@ -1,0 +1,3 @@
+deploy:
+  pre:
+    - bundle exec rake download_theme_liquid_docs

--- a/test/data/shopify_liquid/documentation/filters.json
+++ b/test/data/shopify_liquid/documentation/filters.json
@@ -1,0 +1,51 @@
+[
+  {
+    "category": "collection",
+    "deprecated": false,
+    "deprecation_reason": "",
+    "description": "",
+    "parameters": [
+      {
+        "description": "attribute [string] You can specify the value of supported [HTML attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes).",
+        "name": "HTML",
+        "required": false,
+        "types": [
+
+        ]
+      }
+    ],
+    "return_type": [
+      {
+        "type": "string",
+        "name": "",
+        "description": "",
+        "array_value": ""
+      }
+    ],
+    "examples": [
+      {
+        "name": "",
+        "description": "",
+        "syntax": "",
+        "path": "/",
+        "raw_liquid": "{{ 'Health' | link_to_type }}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "HTML attributes",
+        "description": "You can specify [HTML attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attributes) by including a parameter that matches the attribute name, and the desired value.\n",
+        "syntax": "string | link_to_type: attribute: string",
+        "path": "/",
+        "raw_liquid": "{{ 'Health' | link_to_type: class: 'link-class' }}",
+        "parameter": true,
+        "display_type": "text",
+        "show_data_tab": true
+      }
+    ],
+    "summary": "Generates an HTML `&lt;a&gt;` tag with an `href` attribute linking to a collection page that lists all products of the given\nproduct type.",
+    "syntax": "string | link_to_type",
+    "name": "link_to_type"
+  }
+]

--- a/test/data/shopify_liquid/documentation/objects.json
+++ b/test/data/shopify_liquid/documentation/objects.json
@@ -1,0 +1,159 @@
+[
+  {
+    "access": {
+      "global": false,
+      "parents": [
+        {
+          "object": "product",
+          "property": "media"
+        },
+        {
+          "object": "product",
+          "property": "featured_media"
+        },
+        {
+          "object": "variant",
+          "property": "featured_media"
+        }
+      ],
+      "template": [
+
+      ]
+    },
+    "deprecated": false,
+    "deprecation_reason": "",
+    "description": "The `media` object can be returned by the [`product.media` array](/api/liquid/objects#product-media) or a\n[`file_reference` metafield](/apps/metafields/types).\n\nYou can use [media filters](/api/liquid/filters#media-filters) to generate URLs and media displays. To learn about how\nto use media in your theme, refer to [Support product media](/themes/product-merchandising/media/support-media).\n\n&gt; Note:\n&gt; Each media type has unique properties in addition to the general `media` properties. To learn about these\n&gt; additional properties, refer to the reference for each type.",
+    "properties": [
+      {
+        "deprecated": false,
+        "deprecation_reason": "",
+        "description": "",
+        "examples": [
+
+        ],
+        "return_type": [
+          {
+            "type": "number",
+            "name": "",
+            "description": "",
+            "array_value": ""
+          }
+        ],
+        "summary": "The ID of the media.",
+        "name": "id"
+      },
+      {
+        "deprecated": false,
+        "deprecation_reason": "",
+        "description": "If the source is a [`file_reference` metafield](/apps/metafields/types), then `nil` is returned.",
+        "examples": [
+
+        ],
+        "return_type": [
+          {
+            "type": "number",
+            "name": "",
+            "description": "",
+            "array_value": ""
+          }
+        ],
+        "summary": "The position of the media in the [`product.media` array](/api/liquid/objects#product-media).",
+        "name": "position"
+      },
+      {
+        "deprecated": false,
+        "deprecation_reason": "",
+        "description": "",
+        "examples": [
+          {
+            "name": "Filter for media of a specific type",
+            "description": "You can use the `media_type` property with the [`where` filter](/api/liquid/filters#where) to filter the [`product.media` array](/api/liquid/objects#product-media) for all media of a desired type.\n",
+            "syntax": "",
+            "path": "/products/snake-venom",
+            "raw_liquid": "{% assign images = product.media | where: 'media_type', 'image' %}\n\n{% for image in images %}\n  {{- image | image_url: width: 300 | image_tag }}\n{% endfor %}",
+            "parameter": false,
+            "display_type": "text",
+            "show_data_tab": true
+          }
+        ],
+        "return_type": [
+          {
+            "type": "string",
+            "name": "image",
+            "description": "",
+            "array_value": ""
+          },
+          {
+            "type": "string",
+            "name": "model",
+            "description": "",
+            "array_value": ""
+          },
+          {
+            "type": "string",
+            "name": "video",
+            "description": "",
+            "array_value": ""
+          },
+          {
+            "type": "string",
+            "name": "external_video",
+            "description": "",
+            "array_value": ""
+          }
+        ],
+        "summary": "The media type.",
+        "name": "media_type"
+      },
+      {
+        "deprecated": false,
+        "deprecation_reason": "",
+        "description": "&gt; Note:\n&gt; Preview images don't have an ID attribute.",
+        "examples": [
+
+        ],
+        "return_type": [
+          {
+            "type": "image",
+            "name": "",
+            "description": "",
+            "array_value": ""
+          }
+        ],
+        "summary": "A preview image of the media.",
+        "name": "preview_image"
+      },
+      {
+        "deprecated": false,
+        "deprecation_reason": "",
+        "description": "",
+        "examples": [
+
+        ],
+        "return_type": [
+          {
+            "type": "string",
+            "name": "",
+            "description": "",
+            "array_value": ""
+          }
+        ],
+        "summary": "The alt text of the media.",
+        "name": "alt"
+      }
+    ],
+    "summary": "An abstract media object that can represent the following object types:\n\n- [`image`](/api/liquid/objects#image)\n- [`model`](/api/liquid/objects#model)\n- [`video`](/api/liquid/objects#video)\n- [`external_video`](/api/liquid/objects#external_video)",
+    "name": "media",
+    "examples": [
+
+    ],
+    "json_data": {
+      "path": "/products/dandelion-milk",
+      "handle": "product.media[0]",
+      "data_from_file": ""
+    },
+    "return_type": [
+
+    ]
+  }
+]

--- a/test/data/shopify_liquid/documentation/tags.json
+++ b/test/data/shopify_liquid/documentation/tags.json
@@ -1,0 +1,203 @@
+[
+  {
+    "category": "html",
+    "deprecated": false,
+    "deprecation_reason": "",
+    "description": "Because there are many different form types available in Shopify themes, the `form` tag requires a type. Depending on the\nform type, an additional parameter might be required. You can specify the following form types:\n\n- [`activate_customer_password`](/api/liquid/tags#form-activate_customer_password)\n- [`cart`](/api/liquid/tags#form-cart)\n- [`contact`](/api/liquid/tags#form-contact)\n- [`create_customer`](/api/liquid/tags#form-create_customer)\n- [`currency`](/api/liquid/tags#form-currency)\n- [`customer`](/api/liquid/tags#form-customer)\n- [`customer_address`](/api/liquid/tags#form-customer_address)\n- [`customer_login`](/api/liquid/tags#form-customer_login)\n- [`guest_login`](/api/liquid/tags#form-guest_login)\n- [`localization`](/api/liquid/tags#form-localization)\n- [`new_comment`](/api/liquid/tags#form-new_comment)\n- [`product`](/api/liquid/tags#form-product)\n- [`recover_customer_password`](/api/liquid/tags#form-recover_customer_password)\n- [`reset_customer_password`](/api/liquid/tags#form-reset_customer_password)\n- [`storefront_password`](/api/liquid/tags#form-storefront_password)",
+    "parameters": [
+      {
+        "description": "The desired URL to redirect to when the form submits.",
+        "name": "return_to",
+        "required": false,
+        "types": [
+          "string"
+        ]
+      }
+    ],
+    "summary": "Generates an HTML `&lt;form&gt;` tag, including any required `&lt;input&gt;` tags to submit the form to a specific endpoint.",
+    "name": "form",
+    "syntax": "{% form 'form_type' %}\n  content\n{% endform %}",
+    "syntax_keywords": [
+      {
+        "keyword": "form_type",
+        "description": "The name of the desired form type"
+      },
+      {
+        "keyword": "content",
+        "description": "The form contents"
+      }
+    ],
+    "examples": [
+      {
+        "name": "activate_customer_password",
+        "description": "Generates a form for activating a customer account.\nTo learn more about using this form, and its contents, refer to the [`customers/activate_account` template](/themes/architecture/templates/customers-activate-account#content).\n",
+        "syntax": "{% form 'activate_customer_password', article %}\n  form_content\n{% endform %}\n",
+        "path": "/",
+        "raw_liquid": "{% form 'activate_customer_password' %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "cart",
+        "description": "Generates a form for creating a checkout based on the items currently in the cart. The `cart` form requires a [`cart` object](/api/liquid/objects#cart) as a parameter.\nTo learn more about using the cart form in your theme, refer to the [`cart` template](/themes/architecture/templates/cart#proceed-to-checkout).\n",
+        "syntax": "{% form 'cart', cart %}\n  form_content\n{% endform %}\n",
+        "path": "/",
+        "raw_liquid": "{% form 'cart', cart %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "contact",
+        "description": "Generates a form for submitting an email to the merchant. To learn more about using this form in your theme, refer to [Add a contact form to your theme](/themes/customer-engagement/add-contact-form).\n\n&gt; Tip:\n&gt; To learn more about the merchant experience of receiving submissions, refer to [the Shopify Help Center](https://help.shopify.com/manual/online-store/themes/customizing-themes/add-contact-page#view-contact-form-submissions).\n",
+        "syntax": "{% form 'contact' %}\n  form_content\n{% endform %}\n",
+        "path": "/",
+        "raw_liquid": "{% form 'contact' %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "create_customer",
+        "description": "Generates a form for creating a new customer account.\nTo learn more about using this form, and its contents, refer to the [`customers/register` template](/themes/architecture/templates/customers-register#content).\n",
+        "syntax": "{% form 'create_customer' %}\n  form_content\n{% endform %}\n",
+        "path": "/",
+        "raw_liquid": "{% form 'create_customer' %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "currency",
+        "description": "&gt; Deprecated:\n&gt; The `currency` form is deprecated and has been replaced by the [`localization` form](/api/liquid/tags#form-localization).\n\nGenerates a form for customers to select their preferred currency.\n\n&gt; Tip:\n&gt; Use the [`currency_selector` filter](/api/liquid/filters#currency_selector) to include a currency selector inside the form.\n",
+        "syntax": "{% form 'currency' %}\n  form_content\n{% endform %}\n",
+        "path": "/",
+        "raw_liquid": "{% form 'currency' %}\n  {{ form | currency_selector }}\n{% endform %}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "customer",
+        "description": "Generates a form for creating a new customer without registering a new account. This form is useful for collecting customer information when you don't want customers to log in to your store, such as building a list of emails from a newsletter signup.\n\n&gt; Tip:\n&gt; To generate a form that registers a customer account, use the [`create_customer` form](/api/liquid/tags#form-create_customer).\n\nTo learn more about using this form, and its contents, refer to [Email consent](/themes/customer-engagement/email-consent#newsletter-sign-up-form).\n",
+        "syntax": "{% form 'customer' %}\n  form_content\n{% endform %}\n",
+        "path": "/",
+        "raw_liquid": "{% form 'customer' %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "customer_address",
+        "description": "Generates a form for creating a new address on a customer account, or editing an existing one. The `customer_address` form requires a specific parameter, depending on whether a new address is being created or an existing one is being edited:\n\n| Parameter value | Use-case |\n| --- | --- |\n| `customer.new_address` | When a new address is being created. |\n| `address` | When an existing address is being edited. |\n\nTo learn more about using this form, and its contents, refer to the [`customers/addresses` template](/themes/architecture/templates/customers-addresses#content).\n",
+        "syntax": "{% form 'customer_address', address_type %}\n  form_content\n{% endform %}\n",
+        "path": "/",
+        "raw_liquid": "{% form 'customer_address', customer.new_address %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": false
+      },
+      {
+        "name": "customer_login",
+        "description": "Generates a form for logging into a customer account.\nTo learn more about using this form, and its contents, refer to the [`customers/login` template](/themes/architecture/templates/customers-login#the-customer-login-form).\n",
+        "syntax": "{% form 'customer_login' %}\n  form_content\n{% endform %}\n",
+        "path": "/",
+        "raw_liquid": "{% form 'customer_login' %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "guest_login",
+        "description": "Generates a form, for use in the [`customers/login` template](/themes/architecture/templates/customers-login), that directs customers back to their checkout session as a guest instead of logging in to an account.\nTo learn more about using this form, and its contents, refer to [Offer guest checkout](/themes/architecture/templates/customers-login#offer-guest-checkout).\n",
+        "syntax": "{% form 'guest_login' %}\n  form_content\n{% endform %}\n",
+        "path": "/",
+        "raw_liquid": "{% form 'guest_login' %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "localization",
+        "description": "Generates a form for customers to select their preferred country so that they're shown the appropriate language and currency. The `localization` form can contain one of two selectors:\n\n- A country selector\n- A language selector\n\n&gt; Note:\n&gt; The `localization` form replaces the deprecated [`currency` form](/api/liquid/tags#form-currency).\n\nTo learn more about using this form, and its contents, refer to [Support multiple currencies and languages](/themes/internationalization/multiple-currencies-languages).\n",
+        "syntax": "{% form 'localization' %}\n  form_content\n{% endform %}\n",
+        "path": "/",
+        "raw_liquid": "{% form 'localization' %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "new_comment",
+        "description": "Generates a form for creating a new comment on an article. The `new_comment` form requires an [`article` object](/api/liquid/objects#article) as a parameter.\nTo learn more about using this form, and its contents, refer to the [`article` template](/themes/architecture/templates/article#the-comment-form).\n",
+        "syntax": "{% form 'new_comment', article %}\n  form_content\n{% endform %}\n",
+        "path": "/blogs/potion-notions/how-to-tell-if-you-have-run-out-of-invisibility-potion",
+        "raw_liquid": "{% form 'new_comment', article %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "product",
+        "description": "Generates a form for adding a product variant to the cart. The `product` form requires a [`product` object](/api/liquid/objects#product) as a parameter.\nTo learn more about using this form, and its contents, refer to the [`product` template](/themes/architecture/templates/product#the-product-form).\n",
+        "syntax": "{% form 'product', product %}\n  form_content\n{% endform %}\n",
+        "path": "/products/health-potion",
+        "raw_liquid": "{% form 'product', product %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "recover_customer_password",
+        "description": "Generates a form, for use in the [`customers/login` template](/themes/architecture/templates/customers-login), for a customer to recover a lost or forgotten password.\nTo learn more about using this form, and its contents, refer to [Provide a \"Forgot your password\" option](/themes/architecture/templates/customers-login#provide-a-forgot-your-password-option).\n",
+        "syntax": "{% form 'recover_customer_password' %}\n  form_content\n{% endform %}\n",
+        "path": "/",
+        "raw_liquid": "{% form 'recover_customer_password' %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "reset_customer_password",
+        "description": "Generates a form for a customer to reset their password.\nTo learn more about using this form, and its contents, refer to the [`customers/reset_password` template](/themes/architecture/templates/customers-reset-password#content).\n",
+        "syntax": "{% form 'reset_customer_password' %}\n  form_content\n{% endform %}\n",
+        "path": "/",
+        "raw_liquid": "{% form 'reset_customer_password' %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "storefront_password",
+        "description": "Generates a form for entering a password protected storefront.\nTo learn more about using this form, and its contents, refer to the [`password` template](/themes/architecture/templates/password#the-password-form).\n",
+        "syntax": "{% form 'storefront_password' %}\n  form_content\n{% endform %}\n",
+        "path": "/",
+        "raw_liquid": "{% form 'storefront_password' %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": false,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "return_to",
+        "description": "By default, each form type redirects customers to a specific page after the form submits. For example, the `product` form redirects to the cart page.\n\nThe `return_to` parameter allows you to specify a URL to redirect to. This can be done with the following values:\n\n| Value | Description |\n| --- | --- |\n| `back` | Redirect back to the same page that the customer was on before submitting the form. |\n| A relative path | A specific URL path. For example `/collections/all`. |\n| A [`routes` attribute](/api/liquid/objects#routes) | For example, `routes.root_url` |\n",
+        "syntax": "{% form 'form_type', return_to: string %}\n  content\n{% endform %}\n",
+        "path": "/",
+        "raw_liquid": "{% form 'customer_login', return_to: routes.root_url %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": true,
+        "display_type": "text",
+        "show_data_tab": true
+      },
+      {
+        "name": "HTML attributes",
+        "description": "You can specify [HTML attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attributes) by adding a parameter that matches the attribute name, and the desired value.\n",
+        "syntax": "{% form 'form_type', attribute: string %}\n  content\n{% endform %}\n",
+        "path": "/products/health-potion",
+        "raw_liquid": "{% form \"product\", product, id: 'custom-id', class: 'custom-class', data-example: '100' %}\n  &lt;!-- form content --&gt;\n{% endform %}",
+        "parameter": true,
+        "display_type": "text",
+        "show_data_tab": true
+      }
+    ]
+  }
+]

--- a/test/shopify_liquid/source_manager_test.rb
+++ b/test/shopify_liquid/source_manager_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module ThemeCheck
+  module ShopifyLiquid
+    class SourceManagerTest < Minitest::Test
+      # Use a documentation folder in the test/ directory
+      SOURCE_DOCUMENTATION_DIRECTORY = Pathname.new("#{__dir__}/../data/shopify_liquid/documentation")
+      TEST_DOCUMENTATION_DIRECTORY = Pathname.new("#{__dir__}/../data/shopify_liquid/documentation/tmp")
+
+      def setup
+        SourceManager.stubs(:documentation_directory).returns(TEST_DOCUMENTATION_DIRECTORY)
+        SourceManager.stubs(:open_uri).with(objects_uri).returns(objects_content)
+        SourceManager.stubs(:open_uri).with(filters_uri).returns(filters_content)
+        SourceManager.stubs(:open_uri).with(tags_uri).returns(tags_content)
+      end
+
+      def test_download_creates_directory
+        SourceManager.download
+
+        assert_download_succeeded
+      ensure
+        remove_test_documentation
+      end
+
+      def test_download_overwrites_existing_directory
+        create_dummy_tags_file
+
+        SourceManager.download
+
+        assert_download_succeeded
+      ensure
+        remove_test_documentation
+      end
+
+      def test_has_files_returns_false_in_directory_that_does_not_exist
+        refute(SourceManager.send(:has_required_files?))
+      end
+
+      def test_has_files_returns_false_when_not_all_files_present
+        create_dummy_tags_file
+
+        refute(SourceManager.send(:has_required_files?))
+      ensure
+        remove_test_documentation
+      end
+
+      def test_has_files_returns_true
+        SourceManager.stubs(:documentation_directory).returns(SOURCE_DOCUMENTATION_DIRECTORY)
+
+        assert(SourceManager.send(:has_required_files?))
+      end
+
+      private
+
+      def assert_download_succeeded
+        assert_equal(objects_content, File.read(TEST_DOCUMENTATION_DIRECTORY + "objects.json"))
+        assert_equal(filters_content, File.read(TEST_DOCUMENTATION_DIRECTORY + "filters.json"))
+        assert_equal(tags_content, File.read(TEST_DOCUMENTATION_DIRECTORY + "tags.json"))
+
+        downloaded_files = Dir.glob(TEST_DOCUMENTATION_DIRECTORY + '*')
+          .select { |file| File.file?(file) }
+          .map { |file| File.basename(file) }
+          .to_set
+
+        assert_equal(["filters.json", "objects.json", "tags.json"].to_set, downloaded_files)
+      end
+
+      def objects_uri
+        @objects_uri ||= "https://github.com/Shopify/theme-liquid-docs/raw/main/data/objects.json"
+      end
+
+      def filters_uri
+        @filters_uri ||= "https://github.com/Shopify/theme-liquid-docs/raw/main/data/filters.json"
+      end
+
+      def tags_uri
+        @tags_uri ||= "https://github.com/Shopify/theme-liquid-docs/raw/main/data/tags.json"
+      end
+
+      def objects_content
+        @objects_content ||= load_file(:objects)
+      end
+
+      def filters_content
+        @filters_content ||= load_file(:filters)
+      end
+
+      def tags_content
+        @tags_content ||= load_file(:tags)
+      end
+
+      def remove_test_documentation
+        return unless TEST_DOCUMENTATION_DIRECTORY.exist?
+
+        TEST_DOCUMENTATION_DIRECTORY.rmtree
+      end
+
+      def load_file(file_name)
+        path = SOURCE_DOCUMENTATION_DIRECTORY + "#{file_name}.json"
+        raise "File not found: #{path}" unless File.file?(path)
+        File.read(path)
+      end
+
+      def create_dummy_tags_file
+        Dir.mkdir(TEST_DOCUMENTATION_DIRECTORY) unless TEST_DOCUMENTATION_DIRECTORY.exist?
+        File.open(TEST_DOCUMENTATION_DIRECTORY + 'tags.json', "wb") do |file|
+          file.write({})
+        end
+      end
+    end
+  end
+end

--- a/theme-check.gemspec
+++ b/theme-check.gemspec
@@ -18,7 +18,9 @@ Gem::Specification.new do |spec|
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
   spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do
-    %x{git ls-files -z}.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    # Load all files tracked in git except files in test directory
+    # Include untracked files in liquid documentation folder
+    %x{git ls-files -z}.split("\x0").reject { |f| f.match(%r{^test/}) } + Dir['data/shopify_liquid/documentation/**']
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
### Summary

Closes #650 

- Create a shipit.rubygems.yml to download docs at release phase 
- Update gemspec to include documentation when pushing package to rubygems
- Create rake command to download theme liquid docs 
- Create new module `SourceManager` to handle downloading/refreshing liquid docs
- Use `SourceManager.download_or_refresh_files` in `SourceIndex` when initializing liquid sources
- Create dummy liquid files for `SourceManager` tests 

👋  The number of additions exploded because of new fixtures for liquid objects, to make reviewing easier:
- [This commit](https://github.com/Shopify/theme-check/pull/661/commits/f03601b40b7cbeb353c0a9724eef18116d1a0851) contains the functionality to download theme liquid docs 
- [This commit](https://github.com/Shopify/theme-check/pull/661/commits/31a3f55b80fb1a653aed557863462426dc2363db) contains the new test fixtures

### Tophatting Steps 
<details>
<summary>
This section is a bit verbose so click here to show 🎩 steps
</summary>

#### Download docs locally
All of these steps require `dev up` and a theme-check running locally from the repo

##### Directory gets created and liquid files are downloaded 

1. Delete`data/shopify_liquid/documentation` directory
2. At the root of theme-check in a terminal run `rake download_theme_liquid_docs` and confirm all liquid files appear in `data/shopify_liquid/documentation`
3. Repeat step 1
4. Restart theme-check locally and open a theme in your editor
5. Add ` {{ product. }}` to a liquid file
6. Confirm all liquid files appear in `data/shopify_liquid/documentation`

##### Directory with only partial docs gets overwritten

1. Remove everything in `data/shopify_liquid/documentation`
2. Create a new file called `tags.json` and put anything in it
3. At the root of theme-check in a terminal run `rake download_theme_liquid_docs` and confirm all liquid files appear in `data/shopify_liquid/documentation`
4. Repeat steps 1&2
5. Restart theme-check locally and open a theme in your editor 
6. Add ` {{ product. }}` to a liquid file
7. Confirm all liquid files appear in `data/shopify_liquid/documentation`

#### Confirm docs are in ruby package 
- Checkout `650-liquid-docs-release`
- In a terminal in theme-check root run `dev up`
- Navigate to `lib/theme_check/version.rb` and change version to "0.0.1" (this is only to be sure we're examining the local build of theme-check in later steps)
- Run `rake download_theme_liquid_docs` and confirm docs appear in `data/shopify_liquid/documentation`
- Run `gem build theme-check.gemspec `
- Run `gem unpack theme-check-0.0.1.gem --target ./unpacked-gems`
- Confirm docs are in `unpacked-gems/theme-check-0.0.1/data/shopify_liquid/documentation`

#### Download docs in a deploy (optional)
I've done this myself with shipit-engine locally, feel free to try it out! Some precautions before continuing:
- Be 1000% sure youre not on the production shipit site when clicking "Deploy"
- To help confirm youre not on prod, don't name your new shipit yml environment "rubygems" 

Okay let's go!
- In theme-check, checkout `650-liquid-docs-release` and create a new branch 
- Create a new bash script to run any extra commands to inspect the state of shipit, something like this:
```
#!/usr/bin/env bash

ls -la
```
This isn't required since the shipit console is chatty during deploy

- Create a new file called shipit.staging.yml and populate it with something like this (include your script if you want):
```
deploy:
  pre:
    - bundle exec rake download_theme_liquid_docs
  override:
    - script/override
```
- Commit your new files and push your branch to remote (this is required for shipit to pull the branch)

- `dev clone shipit-engine`
- Follow the steps [here](https://github.com/Shopify/shipit-engine#local-development) to run shipit locally (you may also need to start a new redis instance locally). 
- Navigate to localhost:3000 and click button to `Add a stack`
- Populate the form:
    - Repo should be Shopify/theme-check
    - default branch should point to new branch you pushed up
    - set environment to environment in shipit yaml file (so in my example it would be staging)
    -  _do not_ set deploy to a url
    - Check off `Allow deploys regardless of CI status`
- Click `Create stack`
- Navigate to your new stack, it's possible no commits appear initially. You may have hit the git rate limit
- Once commits appear, Click "Deploy" on latest commit 
- While deploying inspect the console output, confirm docs get cloned 
</details>
