### PR TITLE
Introduce support to range iterations and SFR tags

### DIFF
--- a/lib/theme_check/language_server/completion_providers/assignments_completion_provider.rb
+++ b/lib/theme_check/language_server/completion_providers/assignments_completion_provider.rb
@@ -13,11 +13,10 @@ module ThemeCheck
 
         finder = VariableLookupFinder::AssignmentsFinder.new(content)
         finder.find!
-
-        finder.assignments.map do |label, potential_lookup|
-          object, _property = VariableLookupTraverser.lookup_object_and_property(potential_lookup)
-          object_to_completion(label, object.name)
-        end
+        finder
+          .assignments
+          .map { |label, potential_lookup| object_to_completion(label, object_name(potential_lookup)) }
+          .compact
       end
 
       private
@@ -30,6 +29,11 @@ module ThemeCheck
           kind: CompletionItemKinds::VARIABLE,
           **doc_hash(content),
         }
+      end
+
+      def object_name(potential_lookup)
+        object, _property = VariableLookupTraverser.lookup_object_and_property(potential_lookup)
+        object&.name
       end
     end
   end

--- a/lib/theme_check/language_server/variable_lookup_finder/assignments_finder/scope.rb
+++ b/lib/theme_check/language_server/variable_lookup_finder/assignments_finder/scope.rb
@@ -32,21 +32,37 @@ module ThemeCheck
           def assign_tag_as_potential_lookup(tag)
             variable_lookup = tag.from.name
 
-            unless variable_lookup.is_a?(Liquid::VariableLookup)
-              return PotentialLookup.new(input_type_of(variable_lookup), [], variables)
+            if variable_lookup.is_a?(Liquid::VariableLookup)
+              potential_lookup(variable_lookup)
+            else
+              literal_lookup(variable_lookup)
             end
-
-            name = variable_lookup.name
-            lookups = variable_lookup.lookups
-
-            PotentialLookup.new(name, lookups, variables)
           end
 
           def iteration_tag_as_potential_lookup(tag)
             variable_lookup = tag.collection_name
 
+            case variable_lookup
+            when Liquid::RangeLookup
+              potential_lookup(variable_lookup.start_obj)
+            when Liquid::VariableLookup
+              potential_lookup(variable_lookup, lookups: [*variable_lookup.lookups, 'first'])
+            when Enumerable
+              literal_lookup(variable_lookup.first)
+            else
+              literal_lookup(variable_lookup)
+            end
+          end
+
+          def literal_lookup(variable_lookup)
+            name = input_type_of(variable_lookup)
+
+            PotentialLookup.new(name, [], variables)
+          end
+
+          def potential_lookup(variable_lookup, lookups: nil)
             name = variable_lookup.name
-            lookups = [*variable_lookup.lookups, 'first']
+            lookups ||= variable_lookup.lookups
 
             PotentialLookup.new(name, lookups, variables)
           end

--- a/lib/theme_check/language_server/variable_lookup_finder/assignments_finder/scope_visitor.rb
+++ b/lib/theme_check/language_server/variable_lookup_finder/assignments_finder/scope_visitor.rb
@@ -5,6 +5,8 @@ module ThemeCheck
     module VariableLookupFinder
       class AssignmentsFinder
         class ScopeVisitor
+          SCOPE_UNAWARE_NODES = %i(range range_lookup variable variable_lookup)
+
           attr_reader :global_scope, :current_scope
 
           def initialize
@@ -22,7 +24,7 @@ module ThemeCheck
           private
 
           def visit(node, scope)
-            return if node.type_name == :variable_lookup
+            return if SCOPE_UNAWARE_NODES.include?(node.type_name)
 
             method = :"on_#{node.type_name}"
             scope = @node_handler.send(method, node, scope) if @node_handler.respond_to?(method)

--- a/lib/theme_check/language_server/variable_lookup_finder/tolerant_parser.rb
+++ b/lib/theme_check/language_server/variable_lookup_finder/tolerant_parser.rb
@@ -73,12 +73,32 @@ module ThemeCheck
             include TolerantBlockBody
           end
 
+          class Paginate < Liquid::Tag
+            include TolerantBlockBody
+          end
+
+          class Form < Liquid::Tag
+            include TolerantBlockBody
+          end
+
+          class Style < Liquid::Tag
+            include TolerantBlockBody
+          end
+
+          class Stylesheet < Liquid::Tag
+            include TolerantBlockBody
+          end
+
           def initialize(standard_tags)
             @standard_tags = standard_tags
             @tolerant_tags = {
               'case' => Case,
               'for' => For,
+              'form' => Form,
               'if' => If,
+              'paginate' => Paginate,
+              'style' => Style,
+              'stylesheet' => Stylesheet,
               'tablerow' => TableRow,
               'unless' => Unless,
             }

--- a/test/language_server/completion_providers/assignments_completion_provider_test.rb
+++ b/test/language_server/completion_providers/assignments_completion_provider_test.rb
@@ -12,16 +12,23 @@ module ThemeCheck
           {%- liquid
             assign target = cart
             assign product_2 = product
+            assign columns_mobile_int = section.settings.columns_mobile_int
+            assign show_mobile_slider = false
           %}
           {{
         LIQUID
       end
 
       def test_suggests_assigned_variables
-        ShopifyLiquid::Documentation.expects(:object_doc).with("cart")
-        ShopifyLiquid::Documentation.expects(:object_doc).with("product")
+        ShopifyLiquid::Documentation.stubs(:object_doc).with("cart")
+        ShopifyLiquid::Documentation.stubs(:object_doc).with("boolean")
+        ShopifyLiquid::Documentation.stubs(:object_doc).with("product")
+        ShopifyLiquid::Documentation.stubs(:object_doc).with(nil)
 
+        assert_can_complete_with(@provider, @token, 'target')
         assert_can_complete_with(@provider, @token, 'product_2')
+        assert_can_complete_with(@provider, @token, 'columns_mobile_int')
+        assert_can_complete_with(@provider, @token, 'show_mobile_slider')
       end
 
       def test_does_not_suggest_global_objects

--- a/test/language_server/variable_lookup_finder/assignments_finder_test.rb
+++ b/test/language_server/variable_lookup_finder/assignments_finder_test.rb
@@ -240,6 +240,90 @@ module ThemeCheck
           })
         end
 
+        def test_assignments_finder_with_for_statements_and_ranges
+          template = <<~LIQUID
+            {%- liquid
+              assign var1 = product
+            -%}
+            {%- for var2 in (1..4) -%}
+              {% echo█
+          LIQUID
+
+          assert_assignments_finder(template, {
+            'var1' => 'product',
+            'var2' => 'number',
+          })
+        end
+
+        def test_assignments_finder_with_for_statements_and_complex_ranges
+          template = <<~LIQUID
+            {%- liquid
+              assign var1 = product
+            -%}
+            {% assign var2 = 1 %}
+            {% assign var3 = 4 %}
+            {%- for var4 in (var2..var3) -%}
+              {% echo█
+          LIQUID
+
+          assert_assignments_finder(template, {
+            'var1' => 'product',
+            'var2' => 'number',
+            'var3' => 'number',
+            'var4' => 'var2',
+          })
+        end
+
+        def test_assignments_finder_with_form_tag
+          template = <<~LIQUID
+            {%- form 'localization', id: 'FooterLanguageFormNoScript', class: 'localization-form' -%}
+              {%- for language in localization.available_languages -%}
+                <option value="{{ language.█
+          LIQUID
+
+          assert_assignments_finder(template, {
+            'language' => 'localization',
+          })
+        end
+
+        def test_assignments_finder_with_paginate_tag
+          template = <<~LIQUID
+            {% paginate collection.products by 5 %}
+              {% for var1 in collection.products -%}
+                {% echo █
+          LIQUID
+
+          assert_assignments_finder(template, {
+            'var1' => 'collection',
+          })
+        end
+
+        def test_assignments_finder_with_style_tag
+          template = <<~LIQUID
+            {% style %}
+              .h1 {
+                  {%- for language in localization.available_languages -%}
+                    <option value="{{ language.█
+          LIQUID
+
+          assert_assignments_finder(template, {
+            'language' => 'localization',
+          })
+        end
+
+        def test_assignments_finder_with_stylesheet_tag
+          template = <<~LIQUID
+            {% stylesheet %}
+              .h1 {
+                  {%- for language in localization.available_languages -%}
+                    <option value="{{ language.█
+          LIQUID
+
+          assert_assignments_finder(template, {
+            'language' => 'localization',
+          })
+        end
+
         def test_assignments_finder_with_for_and_else_statements
           template = <<~LIQUID
             {%- liquid

--- a/test/language_server/variable_lookup_finder/assignments_finder_test.rb
+++ b/test/language_server/variable_lookup_finder/assignments_finder_test.rb
@@ -255,7 +255,7 @@ module ThemeCheck
           })
         end
 
-        def test_assignments_finder_with_for_statements_and_complex_ranges
+        def test_assignments_finder_with_for_statements_and_variable_based_ranges
           template = <<~LIQUID
             {%- liquid
               assign var1 = product
@@ -271,6 +271,23 @@ module ThemeCheck
             'var2' => 'number',
             'var3' => 'number',
             'var4' => 'var2',
+          })
+        end
+
+        def test_assignments_finder_with_for_statements_and_variable_and_literal_ranges
+          template = <<~LIQUID
+            {%- liquid
+              assign var1 = product
+            -%}
+            {% assign var2 = 1 %}
+            {%- for var3 in (1..var2) -%}
+              {% echo█
+          LIQUID
+
+          assert_assignments_finder(template, {
+            'var1' => 'product',
+            'var2' => 'number',
+            'var3' => 'number',
           })
         end
 


### PR DESCRIPTION
Fixes https://github.com/Shopify/theme-check/issues/681, https://github.com/Shopify/theme-check/issues/682, and https://github.com/Shopify/theme-check/issues/684
(I've opened a single PR because the fixes intersect a bit in the code, and I'd have dependent PRs)

---

- 681 https://github.com/Shopify/theme-check/issues/681
  - This PR fixes this issue by introducing support to SFR tags in the `TolerantParser`
    ![Screenshot 2022-12-14 at 14 34 33](https://user-images.githubusercontent.com/1079279/207609441-4d2085ed-a49f-4499-89bf-7047a5b695d1.png)


- https://github.com/Shopify/theme-check/issues/682
  - The `AssignmentsCompletionProvider` no longer crashes when it finds an unexpected lookup
    ![Screenshot 2022-12-14 at 14 34 06](https://user-images.githubusercontent.com/1079279/207609469-1efd8026-326f-40b1-8922-172b55d0ba79.png)
    ![Screenshot 2022-12-14 at 14 34 13](https://user-images.githubusercontent.com/1079279/207609488-1aa8e9c5-75f1-4287-9493-bd470f51ccf7.png)


- https://github.com/Shopify/theme-check/issues/684
  - The `Scope` class now supports literal ranges
    ![Screenshot 2022-12-14 at 14 33 51](https://user-images.githubusercontent.com/1079279/207609516-a334c6d9-8c2a-4490-8d79-e5da901192c2.png)


