### PR TITLE
Suggest objects for `paginate`

### DIFF
--- a/lib/theme_check/language_server/variable_lookup_finder/constants.rb
+++ b/lib/theme_check/language_server/variable_lookup_finder/constants.rb
@@ -27,6 +27,7 @@ module ThemeCheck
             \s(?:
               if|elsif|unless|and|or|#{Liquid::Condition.operators.keys.join("|")}
               |echo
+              |paginate
               |case|when
               |cycle
               |in

--- a/test/language_server/variable_lookup_finder_test.rb
+++ b/test/language_server/variable_lookup_finder_test.rb
@@ -123,6 +123,10 @@ module ThemeCheck
         assert_can_lookup_tag("cycle '', cart.error", "cart.error")
       end
 
+      def test_can_lookup_paginate_statements
+        assert_can_lookup('{% paginate %}', '', -2)
+      end
+
       def test_can_lookup_for_statements
         assert_can_lookup_tag("for p in ", "")
         assert_can_lookup_tag("for p in cart", "cart")


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #683 

### WHAT is this pull request doing?

Treats `paginate` in a similar way as `echo`, so that suggestions are shown.

Use cases like `{% paginate customer.orders` will be treated in #687.

### How to test your changes?

Verify that at the cursor position of `{% paginate ⬜️`, suggestions are made.