### PR TITLE
Only suggest filters available in SourceIndex

### DIFF
--- a/lib/theme_check/language_server/completion_providers/filter_completion_provider.rb
+++ b/lib/theme_check/language_server/completion_providers/filter_completion_provider.rb
@@ -49,7 +49,7 @@ module ThemeCheck
       end
 
       def available_filters_for(input_type)
-        filters = ShopifyLiquid::Filter.filters
+        filters = ShopifyLiquid::SourceIndex.filters
           .select { |filter| input_type.nil? || filter.input_type == input_type }
         return all_labels if filters.empty?
         return filters if input_type == INPUT_TYPE_VARIABLE

--- a/lib/theme_check/shopify_liquid/filter.rb
+++ b/lib/theme_check/shopify_liquid/filter.rb
@@ -40,24 +40,8 @@ module ThemeCheck
         "debug",
       ]
 
-      def filters
-        @filters ||= SourceIndex.filters +
-          LABELS_NOT_IN_SOURCE_INDEX.map { |name| build_filter_entry_for(name) }.freeze
-      end
-
       def labels
         @labels ||= SourceIndex.filters.map(&:name) + LABELS_NOT_IN_SOURCE_INDEX
-      end
-
-      private
-
-      def build_filter_entry_for(name)
-        SourceIndex::FilterEntry.new({
-          "name" => name,
-          "summary" => name,
-          "syntax" => "variable | ",
-          "return_type" => [],
-        })
       end
     end
   end

--- a/test/language_server/completion_providers/filter_completion_provider_test.rb
+++ b/test/language_server/completion_providers/filter_completion_provider_test.rb
@@ -38,12 +38,10 @@ module ThemeCheck
         assert_can_complete_with(@provider, "{{ 'foo.js' | ", "asset_url")
         assert_can_complete_with(@provider, "{{ 'foo.js' | asset", "asset_url")
         assert_can_complete_with(@provider, "{{ 'foo.js' | asset_url | image", "image_url")
-      end
 
-      def test_completions_for_filters_not_in_source_index
         filter_not_in_source_index = 'installments_pricing'
         assert_includes(ShopifyLiquid::Filter::LABELS_NOT_IN_SOURCE_INDEX, filter_not_in_source_index)
-        assert_can_complete_with(@provider, "{{ 'foo.js' | ", filter_not_in_source_index)
+        refute_can_complete_with(@provider, "{{ 'foo.js' | ", filter_not_in_source_index)
       end
 
       def test_completions_with_content_after_cursor

--- a/test/shopify_liquid_test.rb
+++ b/test/shopify_liquid_test.rb
@@ -15,10 +15,6 @@ class ShopifyLiquidTest < Minitest::Test
     assert_equal(168, ThemeCheck::ShopifyLiquid::Filter.labels.size)
   end
 
-  def test_filter_filters
-    assert_equal(168, ThemeCheck::ShopifyLiquid::Filter.filters.size)
-  end
-
   def test_object_labels
     assert_equal(119, ThemeCheck::ShopifyLiquid::Object.labels.size)
   end


### PR DESCRIPTION
### WHY are these changes introduced?

Relates to #656 and #674, rolls back changes to filters suggestion.

### WHAT is this pull request doing?

- Filters that were previously in `data/shopify_liquid/filters.yml` will not be suggested.
- Theme Check will accept these filters though.

### How to test your changes?

- Verify that code completion for tags is still working as before,
  - and that [the tags mentioned in `LABELS_NOT_IN_SOURCE_INDEX`](https://github.com/Shopify/theme-check/blob/fix-656/lib/theme_check/shopify_liquid/tag.rb#L9) keep being suggested.
- Verify that code completion for objects is still working as before,
  - and that `customer_address` and `product_variant` keep being suggested, but offer no further suggestions like attribute suggestions.
- :warning: Verify that [the filters mentioned in `LABELS_NOT_IN_SOURCE_INDEX`](https://github.com/Shopify/theme-check/blob/fix-656/lib/theme_check/shopify_liquid/filter.rb#L9) are **not** suggested anymore.