### PR TITLE
`ObjectCompletionProviderd` should not provide completion items that don't live in the `SourceIndex`

### DIFF
--- a/test/language_server/completion_providers/object_completion_provider_test.rb
+++ b/test/language_server/completion_providers/object_completion_provider_test.rb
@@ -55,9 +55,7 @@ module ThemeCheck
         assert_can_complete_with(@provider, "{{ all_", 'all_products')
 
         object_not_in_source_index = 'customer_address'
-        assert_includes(ShopifyLiquid::Object::LABELS_NOT_IN_SOURCE_INDEX, object_not_in_source_index)
-        assert_can_complete_with(@provider, "{{ cust", object_not_in_source_index)
-
+        refute_can_complete_with(@provider, "{{ cust", object_not_in_source_index)
         refute_can_complete_with(@provider, "{{ all_", 'cart')
       end
     end


### PR DESCRIPTION
The CI was passing on https://github.com/Shopify/theme-check/pull/688, however the branch was missing a rebase with `main`.

This PR fixes the CI issue.