### PR TITLE
Add support for new sections liquid tag in theme check

### DIFF
--- a/docs/checks/app_block_valid_tags.md
+++ b/docs/checks/app_block_valid_tags.md
@@ -11,6 +11,7 @@ This rule verifies none of the below tags are used in theme app extension blocks
 - `{% include 'foo' %}`
 - `{% layout 'foo' %}`
 - `{% section 'foo' %}`
+- `{% sections 'foo' %}`
 
 :-1: **Incorrect** code for this check occurs with the use of any of the above tags in the liquid code of theme app extension blocks.
 

--- a/lib/theme_check/checks/app_block_valid_tags.rb
+++ b/lib/theme_check/checks/app_block_valid_tags.rb
@@ -32,5 +32,9 @@ module ThemeCheck
     def on_section(node)
       add_offense(OFFENSE_MSG % 'section', node: node)
     end
+
+    def on_sections(node)
+      add_offense(OFFENSE_MSG % 'sections', node: node)
+    end
   end
 end

--- a/lib/theme_check/tags.rb
+++ b/lib/theme_check/tags.rb
@@ -22,6 +22,24 @@ module ThemeCheck
       end
     end
 
+    class Sections < Liquid::Tag
+      SYNTAX = /\A\s*(?<sections_name>#{Liquid::QuotedString})\s*\z/o
+
+      attr_reader :sections_name
+
+      def initialize(tag_name, markup, options)
+        super
+
+        match = markup.match(SYNTAX)
+        raise(
+          Liquid::SyntaxError,
+          "Error in tag 'sections' - Valid syntax: sections '[type]'",
+        ) unless match
+        @sections_name = match[:sections_name].tr(%('"), '')
+        @sections_name.chomp!(".liquid") if @sections_name.end_with?(".liquid")
+      end
+    end
+
     class Form < Liquid::Block
       TAG_ATTRIBUTES = /([\w\-]+)\s*:\s*(#{Liquid::QuotedFragment})/o
       # Matches forms with arguments:
@@ -204,6 +222,7 @@ module ThemeCheck
         register_tag('render', Render)
         register_tag('paginate', Paginate)
         register_tag('section', Section)
+        register_tag('sections', Sections)
         register_tag('style', Style)
         register_tag('schema', Schema)
         register_tag('javascript', Javascript)

--- a/test/checks/app_block_valid_tags_test.rb
+++ b/test/checks/app_block_valid_tags_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 module ThemeCheck
   class AppBlockValidTagsTest < Minitest::Test
     def test_include_layout_section_tags
-      ['include', 'layout', 'section'].each do |tag|
+      ['include', 'layout', 'section', 'sections'].each do |tag|
         extension_files = {
           "blocks/app.liquid" => <<~BLOCK,
             {% #{tag} 'test' %}

--- a/test/checks/liquid_tag_test.rb
+++ b/test/checks/liquid_tag_test.rb
@@ -51,4 +51,14 @@ class LiquidTagTest < Minitest::Test
     )
     assert_offenses("", offenses)
   end
+
+  def test_allows_sections_tag_in_layout
+    offenses = analyze_theme(
+      "sections/theme.liquid" => <<~END,
+        {% sections 'foo' %}
+      END
+    )
+
+    assert_offenses("", offenses)
+  end
 end


### PR DESCRIPTION
### WHY are these changes introduced?
As we are planning to introduce a new liquid tag to render section groups, we want to make sure Theme Check is able to recognize and handle the new liquid tag. 

### WHAT is this pull request doing?
- Registering a new liquid tag: `sections`
- The new liquid tag will have the following format: 
`{% sections '<type>' %}`

- The new liquid tag only allowed in themes. 