### PR TITLE
Add shopify-dev link to suggestion title

### DIFF
--- a/lib/theme_check/shopify_liquid/documentation/markdown_template.rb
+++ b/lib/theme_check/shopify_liquid/documentation/markdown_template.rb
@@ -16,7 +16,7 @@ module ThemeCheck
         private
 
         def title(entry)
-          "### #{entry.name}"
+          "### [#{entry.name}](#{entry.shopify_dev_url})"
         end
 
         def body(entry)

--- a/lib/theme_check/shopify_liquid/source_index/base_entry.rb
+++ b/lib/theme_check/shopify_liquid/source_index/base_entry.rb
@@ -12,6 +12,8 @@ module ThemeCheck
 
         def_delegators :return_type_instance, :generic_type?, :array_type?, :array_type, :to_s, :denied_filters
 
+        SHOPIFY_DEV_ROOT_URL = "https://shopify.dev/api/liquid"
+
         def initialize(hash = {})
           @hash = hash || {}
           @return_type = nil
@@ -37,6 +39,10 @@ module ThemeCheck
           return nil unless deprecated?
 
           hash['deprecation_reason'] || nil
+        end
+
+        def shopify_dev_url
+          SHOPIFY_DEV_ROOT_URL
         end
 
         attr_writer :return_type

--- a/lib/theme_check/shopify_liquid/source_index/filter_entry.rb
+++ b/lib/theme_check/shopify_liquid/source_index/filter_entry.rb
@@ -12,6 +12,10 @@ module ThemeCheck
         def input_type
           @input_type ||= hash['syntax'].split(' | ')[0]
         end
+
+        def shopify_dev_url
+          "#{SHOPIFY_DEV_ROOT_URL}/filters/#{hash['name']}"
+        end
       end
     end
   end

--- a/lib/theme_check/shopify_liquid/source_index/object_entry.rb
+++ b/lib/theme_check/shopify_liquid/source_index/object_entry.rb
@@ -6,7 +6,13 @@ module ThemeCheck
       class ObjectEntry < BaseEntry
         def properties
           (hash['properties'] || [])
-            .map { |hash| PropertyEntry.new(hash) }
+            .map do |prop_hash|
+              PropertyEntry.new(prop_hash, hash['name'])
+            end
+        end
+
+        def shopify_dev_url
+          "#{SHOPIFY_DEV_ROOT_URL}/objects/#{hash['name']}"
         end
       end
     end

--- a/lib/theme_check/shopify_liquid/source_index/parameter_entry.rb
+++ b/lib/theme_check/shopify_liquid/source_index/parameter_entry.rb
@@ -8,6 +8,10 @@ module ThemeCheck
           nil
         end
 
+        def shopify_dev_url
+          "#{SHOPIFY_DEV_ROOT_URL}/filters/#{hash['name']}"
+        end
+
         private
 
         def return_type_hash

--- a/lib/theme_check/shopify_liquid/source_index/property_entry.rb
+++ b/lib/theme_check/shopify_liquid/source_index/property_entry.rb
@@ -3,7 +3,19 @@
 module ThemeCheck
   module ShopifyLiquid
     class SourceIndex
-      class PropertyEntry < BaseEntry; end
+      class PropertyEntry < BaseEntry
+        attr_reader :parent_name
+
+        def initialize(hash, parent_name)
+          @hash = hash || {}
+          @return_type = nil
+          @parent_name = parent_name
+        end
+
+        def shopify_dev_url
+          "#{SHOPIFY_DEV_ROOT_URL}/objects/#{parent_name}##{parent_name}-#{hash['name']}"
+        end
+      end
     end
   end
 end

--- a/lib/theme_check/shopify_liquid/source_index/tag_entry.rb
+++ b/lib/theme_check/shopify_liquid/source_index/tag_entry.rb
@@ -14,6 +14,10 @@ module ThemeCheck
             'type' => "tag<#{name}>",
           }
         end
+
+        def shopify_dev_url
+          "#{SHOPIFY_DEV_ROOT_URL}/tags/#{hash['name']}"
+        end
       end
     end
   end

--- a/test/shopify_liquid/documentation/markdown_template_test.rb
+++ b/test/shopify_liquid/documentation/markdown_template_test.rb
@@ -11,19 +11,19 @@ module ThemeCheck
         end
 
         def test_render
-          entry = SourceIndex::BaseEntry.new(
+          entry = SourceIndex::ObjectEntry.new(
             'name' => 'product',
             'summary' => 'A product in the store.',
             'description' => 'A more detailed description of a product in the store.',
           )
 
-          actual_temaplte = @markdown_template.render(entry)
-          expected_template = "### product\n" \
+          actual_template = @markdown_template.render(entry)
+          expected_template = "### [product](https://shopify.dev/api/liquid/objects/product)\n" \
             "A product in the store.\n" \
             "\n---\n\n" \
             "A more detailed description of a product in the store."
 
-          assert_equal(expected_template, actual_temaplte)
+          assert_equal(expected_template, actual_template)
         end
 
         def test_render_with_summary_only
@@ -32,11 +32,11 @@ module ThemeCheck
             'summary' => 'A product in the store.'
           )
 
-          actual_temaplte = @markdown_template.render(entry)
-          expected_template = "### product\n" \
+          actual_template = @markdown_template.render(entry)
+          expected_template = "### [product](https://shopify.dev/api/liquid)\n" \
             "A product in the store." \
 
-          assert_equal(expected_template, actual_temaplte)
+          assert_equal(expected_template, actual_template)
         end
 
         def test_render_with_description_only
@@ -45,11 +45,11 @@ module ThemeCheck
             'description' => 'A more detailed description of a product in the store.'
           )
 
-          actual_temaplte = @markdown_template.render(entry)
-          expected_template = "### product\n" \
+          actual_template = @markdown_template.render(entry)
+          expected_template = "### [product](https://shopify.dev/api/liquid)\n" \
             "A more detailed description of a product in the store." \
 
-          assert_equal(expected_template, actual_temaplte)
+          assert_equal(expected_template, actual_template)
         end
 
         def test_render_with_shopify_dev_urls
@@ -62,13 +62,77 @@ module ThemeCheck
             BODY
           )
 
-          actual_temaplte = @markdown_template.render(entry)
-          expected_template = "### product\n" \
+          actual_template = @markdown_template.render(entry)
+          expected_template = "### [product](https://shopify.dev/api/liquid)\n" \
             "When you render [...] [`include` tag](https://shopify.dev/api/liquid/tags#include) [...],\n" \
             "[`if`](https://shopify.dev/api/liquid/tags#if) [`if`](https://shopify.dev/api/liquid/tags#if)\n" \
             "[`unless`](https://shopify.dev/api/liquid/tags#unless) Allows you to specify a [...]\n" \
 
-          assert_equal(expected_template, actual_temaplte)
+          assert_equal(expected_template, actual_template)
+        end
+
+        def test_object_property_entry_title_link
+          entry = SourceIndex::ObjectEntry.new(
+            'name' => 'product',
+            'properties' => [
+              {
+                "name" => "created_at",
+                "summary" => "A timestamp for when the product was created.",
+              },
+            ]
+          )
+
+          actual_template = @markdown_template.render(entry.properties[0])
+          expected_template = "### [created_at](https://shopify.dev/api/liquid/objects/product#product-created_at)\n" \
+            "A timestamp for when the product was created."
+
+          assert_equal(expected_template, actual_template)
+        end
+
+        def test_tag_entry_title_link
+          entry = SourceIndex::TagEntry.new(
+            "name" => "if",
+            "summary" => "Renders an expression if a specific condition is `true`.",
+          )
+
+          actual_template = @markdown_template.render(entry)
+
+          expected_template = "### [if](https://shopify.dev/api/liquid/tags/if)\n" \
+            "Renders an expression if a specific condition is `true`."
+
+          assert_equal(expected_template, actual_template)
+        end
+
+        def test_filter_title_link
+          entry = SourceIndex::FilterEntry.new(
+            "name" => "payment_type_img_url",
+            "summary" => "Returns the URL for an SVG image of a given [payment type](/api/liquid/objects/shop#shop-enabled_payment_types).",
+          )
+
+          actual_template = @markdown_template.render(entry)
+
+          expected_template = "### [payment_type_img_url](https://shopify.dev/api/liquid/filters/payment_type_img_url)\n" \
+            "Returns the URL for an SVG image of a given [payment type](https://shopify.dev/api/liquid/objects/shop#shop-enabled_payment_types)."
+
+          assert_equal(expected_template, actual_template)
+        end
+
+        def test_filter_parameter_entry_title_link
+          entry = SourceIndex::FilterEntry.new(
+            "name" => "stylesheet_tag",
+            "summary" => "Generates an HTML `&lt;link&gt;` tag for a given resource URL.",
+            "parameters" => [
+              "description" => "The type of media that the resource applies to.",
+              "name" => "media",
+            ]
+          )
+
+          actual_template = @markdown_template.render(entry.parameters[0])
+
+          expected_template = "### [media](https://shopify.dev/api/liquid/filters/media)\n" \
+            "The type of media that the resource applies to."
+
+          assert_equal(expected_template, actual_template)
         end
       end
     end

--- a/test/shopify_liquid/documentation_test.rb
+++ b/test/shopify_liquid/documentation_test.rb
@@ -9,7 +9,7 @@ module ThemeCheck
         SourceIndex.stubs(:filters).returns([filter_entry])
 
         actual_doc = Documentation.filter_doc('size')
-        expected_doc = "### size\n" \
+        expected_doc = "### [size](https://shopify.dev/api/liquid/filters/size)\n" \
           "Returns the size of a string or array.\n" \
           "\n---\n\n" \
           'You can use the "size" filter with dot notation.'
@@ -21,7 +21,7 @@ module ThemeCheck
         SourceIndex.stubs(:tags).returns([tag_entry])
 
         actual_doc = Documentation.tag_doc('tablerow')
-        expected_doc = "### tablerow\n" \
+        expected_doc = "### [tablerow](https://shopify.dev/api/liquid/tags/tablerow)\n" \
           'The "tablerow" tag must be wrapped in HTML "table" tags.' \
 
         assert_equal(expected_doc, actual_doc)
@@ -31,7 +31,7 @@ module ThemeCheck
         SourceIndex.stubs(:objects).returns([object_entry])
 
         actual_doc = Documentation.object_doc('product')
-        expected_doc = "### product\n" \
+        expected_doc = "### [product](https://shopify.dev/api/liquid/objects/product)\n" \
           'A product in the store.'
 
         assert_equal(expected_doc, actual_doc)
@@ -41,7 +41,7 @@ module ThemeCheck
         SourceIndex.stubs(:objects).returns([object_entry])
 
         actual_doc = Documentation.object_property_doc('product', 'available')
-        expected_doc = "### available\n" \
+        expected_doc = "### [available](https://shopify.dev/api/liquid/objects/product#product-available)\n" \
           'Returns "true" if at least one of the variants of the product is available.'
 
         assert_equal(expected_doc, actual_doc)

--- a/test/shopify_liquid/source_index/property_entry_test.rb
+++ b/test/shopify_liquid/source_index/property_entry_test.rb
@@ -7,7 +7,7 @@ module ThemeCheck
     class SourceIndex
       class PropertyEntryTest < Minitest::Test
         def setup
-          @entry = PropertyEntry.new(hash)
+          @entry = PropertyEntry.new(hash, "user_agent")
         end
 
         def test_return_type


### PR DESCRIPTION
Closes https://github.com/Shopify/theme-check/issues/699

### Summary

- Update the markdown template to link to shopify-dev in the suggestion title
- Add shopify-dev urls to all entry possibilities for intelligent code completion 

### Tophatting
Open a theme and test the following scenarios. Type the following and at the cursor type Ctrl-Space. When a suggestion appears, click the title link. Confirm the link is a sensible suggestion for what you typed. Object properties can be deep linked but tag parameters cannot

#### Object

`{{ address█ }}`

#### Object property 

`{{ address.cit█ }}` 

#### Tag

`{% if█ %}`

#### Filter 

`{{ cart | external_video_tag█ }}`

#### Filter parameter

TODO -- I can't seem to find an example for this case where we suggest a filter parameter?
