### PR TITLE
Avoid strict dependency between `Shopify/theme-check` unit tests and `Shopify/theme-liquid-docs`

### DIFF
--- a/test/shopify_liquid/source_index_test.rb
+++ b/test/shopify_liquid/source_index_test.rb
@@ -20,7 +20,7 @@ module ThemeCheck
           .stubs(:default_destination)
           .returns(SourceManager.send(:default_destination))
         @source_index_class.filters
-        assert_equal(138, @source_index_class.filters.length)
+        assert_operator(@source_index_class.filters.length, :>=, 138)
 
         SourceIndex::FilterState.mark_outdated
         assert(SourceIndex::FilterState.outdated?)
@@ -48,7 +48,7 @@ module ThemeCheck
           .stubs(:default_destination)
           .returns(SourceManager.send(:default_destination))
         @source_index_class.objects
-        assert_equal(111, @source_index_class.objects.length)
+        assert_operator(@source_index_class.objects.length, :>=, 111)
 
         SourceIndex::ObjectState.mark_outdated
         assert(SourceIndex::ObjectState.outdated?)
@@ -76,7 +76,7 @@ module ThemeCheck
           .stubs(:default_destination)
           .returns(SourceManager.send(:default_destination))
         @source_index_class.tags
-        assert_equal(27, @source_index_class.tags.length)
+        assert_operator(@source_index_class.tags.length, :>=, 27)
 
         SourceIndex::TagState.mark_outdated
         assert(SourceIndex::TagState.outdated?)

--- a/test/shopify_liquid_test.rb
+++ b/test/shopify_liquid_test.rb
@@ -12,10 +12,10 @@ class ShopifyLiquidTest < Minitest::Test
   end
 
   def test_filter_labels
-    assert_equal(169, ThemeCheck::ShopifyLiquid::Filter.labels.size)
+    assert_operator(ThemeCheck::ShopifyLiquid::Filter.labels.size, :>=, 169)
   end
 
   def test_object_labels
-    assert_equal(119, ThemeCheck::ShopifyLiquid::Object.labels.size)
+    assert_operator(ThemeCheck::ShopifyLiquid::Object.labels.size, :>=, 119)
   end
 end


### PR DESCRIPTION
This PR removes `assert_equal(exp, act)` in favor of `assert_operator(act, :>=, min_exp)`.

Thus, `Shopify/theme-check` unit tests will no longer break when new types get documented at `Shopify/theme-liquid-docs`.