### PR TITLE
Introduce `--update-docs` flag to synchronously update Theme Check resources (objects, filters, and tags)

### DIFF
--- a/lib/theme_check/cli.rb
+++ b/lib/theme_check/cli.rb
@@ -15,6 +15,7 @@ module ThemeCheck
       @include_categories = []
       @exclude_categories = []
       @auto_correct = false
+      @update_resources = false
       @config_path = nil
       @fail_level = :error
       @format = :text
@@ -65,6 +66,10 @@ module ThemeCheck
         "--print",
         "Output active config to STDOUT"
       ) { @command = :print }
+      @option_parser.on(
+        "--update-resources",
+        "Update Theme Check resources (objects, filters, and tags)"
+      ) { @update_resources = true }
       @option_parser.on(
         "-h", "--help",
         "Show this. Hi!"
@@ -181,6 +186,8 @@ module ThemeCheck
     end
 
     def check(out_stream = STDOUT)
+      update_resources
+
       STDERR.puts "Checking #{@config.root} ..."
       storage = ThemeCheck::FileSystemStorage.new(@config.root, ignored_patterns: @config.ignored_patterns)
       theme = ThemeCheck::Theme.new(storage)
@@ -197,6 +204,14 @@ module ThemeCheck
       raise Abort, "" if analyzer.uncorrectable_offenses.any? do |offense|
         offense.check.severity_value <= Check.severity_value(@fail_level)
       end
+    end
+
+    def update_resources
+      return unless @update_resources
+
+      puts 'Updating resources...'
+
+      ThemeCheck::ShopifyLiquid::SourceManager.download
     end
 
     def profile

--- a/lib/theme_check/cli.rb
+++ b/lib/theme_check/cli.rb
@@ -15,7 +15,7 @@ module ThemeCheck
       @include_categories = []
       @exclude_categories = []
       @auto_correct = false
-      @update_resources = false
+      @update_docs = false
       @config_path = nil
       @fail_level = :error
       @format = :text
@@ -67,9 +67,9 @@ module ThemeCheck
         "Output active config to STDOUT"
       ) { @command = :print }
       @option_parser.on(
-        "--update-resources",
-        "Update Theme Check resources (objects, filters, and tags)"
-      ) { @update_resources = true }
+        "--update-docs",
+        "Update Theme Check docs (objects, filters, and tags)"
+      ) { @update_docs = true }
       @option_parser.on(
         "-h", "--help",
         "Show this. Hi!"
@@ -186,7 +186,7 @@ module ThemeCheck
     end
 
     def check(out_stream = STDOUT)
-      update_resources
+      update_docs
 
       STDERR.puts "Checking #{@config.root} ..."
       storage = ThemeCheck::FileSystemStorage.new(@config.root, ignored_patterns: @config.ignored_patterns)
@@ -206,10 +206,10 @@ module ThemeCheck
       end
     end
 
-    def update_resources
-      return unless @update_resources
+    def update_docs
+      return unless @update_docs
 
-      puts 'Updating resources...'
+      puts 'Updating documentation...'
 
       ThemeCheck::ShopifyLiquid::SourceManager.download
     end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -175,7 +175,7 @@ class CliTest < Minitest::Test
     assert_includes(out, "LiquidTag:")
   end
 
-  def test_update_resources
+  def test_update_docs
     ThemeCheck::ShopifyLiquid::SourceManager.expects(:download)
 
     storage = make_file_system_storage(
@@ -188,10 +188,10 @@ class CliTest < Minitest::Test
     )
 
     out, _err = capture_io do
-      ThemeCheck::Cli.parse_and_run!([storage.root, '--update-resources'])
+      ThemeCheck::Cli.parse_and_run!([storage.root, '--update-docs'])
     end
 
-    assert_includes(out, 'Updating resources...')
+    assert_includes(out, 'Updating documentation...')
   end
 
   def test_auto_correct

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -175,6 +175,25 @@ class CliTest < Minitest::Test
     assert_includes(out, "LiquidTag:")
   end
 
+  def test_update_resources
+    ThemeCheck::ShopifyLiquid::SourceManager.expects(:download)
+
+    storage = make_file_system_storage(
+      'layout/theme.liquid' => '',
+      '.theme-check.yml' => <<~YAML,
+        extends: :nothing
+        RequiredDirectories:
+          enabled: false
+      YAML
+    )
+
+    out, _err = capture_io do
+      ThemeCheck::Cli.parse_and_run!([storage.root, '--update-resources'])
+    end
+
+    assert_includes(out, 'Updating resources...')
+  end
+
   def test_auto_correct
     storage = make_file_system_storage(
       "templats/theme.liquid" => <<~LIQUID,


### PR DESCRIPTION
Fixes part of https://github.com/Shopify/theme-check/issues/706 (a following PR is going to update `Shopify/theme-check-action`)

## Summary

This PR introduces a flag to synchronously update Theme Check documentation (objects, filters, and tags).

#### Context

When Theme Check is released, the most updated version of `Shopify/theme-liquid-docs` is embedded. Also, when some new filter is released, local Theme Check instances get auto upgraded asynchronously (so documentation is always updated on developers machines).

However, at CI environments, Theme Check uses the embedded documentation from the latest release, which makes the build of some CI-users fail.

## How to test this PR

- Download this [filters.json](https://gist.githubusercontent.com/karreiro/2f67793ed1cf15566dfd2833b256e409/raw/1e6adfb67d2b43dfa08ebba219aed8d40dc0a798/filters.json) file
- Replace your local `filters.json` file (`data/shopify_liquid/documentation/filters.json`) with the one above
- Run `shopify-dev theme init`
- Remove the comments from the `sections/footer.liquid` file (line ~192, around the `login_button` filter)
- Run `bin/theme-check <theme_directory> | grep sections/footer.liquid`
- Notice that Theme Check raises an error
- Run `bin/theme-check <theme_directory> --update-docs | grep sections/footer.liquid`
- Notice that errors are no longer raised

## Post-release steps

- Update Theme Check [docs](https://shopify.dev/themes/tools/theme-check/commands#flags)
- Update Theme Check [action](https://github.com/Shopify/theme-check-action)