### PR TITLE
The `--update-docs` messages should use the STDERR

### DIFF
--- a/lib/theme_check/cli.rb
+++ b/lib/theme_check/cli.rb
@@ -209,7 +209,7 @@ module ThemeCheck
     def update_docs
       return unless @update_docs
 
-      puts 'Updating documentation...'
+      STDERR.puts 'Updating documentation...'
 
       ThemeCheck::ShopifyLiquid::SourceManager.download
     end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -187,11 +187,11 @@ class CliTest < Minitest::Test
       YAML
     )
 
-    out, _err = capture_io do
+    _out, err = capture_io do
       ThemeCheck::Cli.parse_and_run!([storage.root, '--update-docs'])
     end
 
-    assert_includes(out, 'Updating documentation...')
+    assert_includes(err, 'Updating documentation...')
   end
 
   def test_auto_correct


### PR DESCRIPTION
The `--update-docs` messages should use the STDERR [1], as it should inform users but not interfere with scripting when piping (re: https://github.com/Shopify/theme-check-action/pull/19#discussion_r1109019038).

[1] https://clig.dev/#the-basics

