### PR TITLE
Introduce action to auto add issues to the Theme Developer Tools project

### DIFF
--- a/.github/workflows/add-theme-check-issues-to-theme-developer-tools-project.yml
+++ b/.github/workflows/add-theme-check-issues-to-theme-developer-tools-project.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - labeled
+      - transferred
 
 jobs:
   add-to-project:
@@ -14,4 +15,4 @@ jobs:
       - uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/Shopify/projects/2929
-          github-token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add-theme-check-issues-to-theme-developer-tools-project.yml
+++ b/.github/workflows/add-theme-check-issues-to-theme-developer-tools-project.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/Shopify/projects/2929
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}

--- a/.github/workflows/add-theme-check-issues-to-theme-developer-tools-project.yml
+++ b/.github/workflows/add-theme-check-issues-to-theme-developer-tools-project.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   add-to-project:
     name: Add issues to the Theme Developer Tools project
-    runs-on: shopify-ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@main
         with:

--- a/.github/workflows/add_theme_check_issues_to_theme_developer_tools_project.yml
+++ b/.github/workflows/add_theme_check_issues_to_theme_developer_tools_project.yml
@@ -1,0 +1,17 @@
+# https://github.com/actions/add-to-project
+name: Add issues to the Theme Developer Tools project
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add issues to the Theme Developer Tools project
+    runs-on: shopify-ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/Shopify/projects/2929
+          github-token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}


### PR DESCRIPTION
Introduce GitHub action to auto add issues to the Theme Developer Tools project.

Requires https://github.com/Shopify/github-actions-access-provider/pull/607