### PR TITLE
Skip font preload warning

### DIFF
--- a/docs/checks/asset_preload.md
+++ b/docs/checks/asset_preload.md
@@ -6,6 +6,13 @@ Preloading can be a useful way of making sure that critical assets are downloade
 
 Liquid provides multiple filters to [preload key resources][preload_key_resources] so they can be converted into `Link` headers automatically. This enables them to be discovered even faster, especially when combined with Early Hints that Shopify supports.
 
+Third party assets and font preloads that are not supported by `preload_tag` are ignored by this check:
+
+```liquid
+<!-- safely ignored -->
+<link rel="preload" as="script" href="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js">
+```
+
 ## Examples
 
 The following examples contain code snippets that either fail or pass this check.

--- a/lib/theme_check/checks/asset_preload.rb
+++ b/lib/theme_check/checks/asset_preload.rb
@@ -6,10 +6,12 @@ module ThemeCheck
     doc docs_url(__FILE__)
 
     def on_link(node)
-      return if node.attributes["rel"]&.downcase != "preload"
+      return unless node.attributes["rel"]&.downcase == "preload"
+      return if node.literal? # literal urls cannot use the preload_tag
+      return unless node.attributes["href"]&.match?(/(?:assets?|image|file)_url\b/i)
       case node.attributes["as"]&.downcase
       when "font"
-        # Ignored as it is not supported
+        # fonts are not supported yet
       when "style"
         add_offense("For better performance, prefer using the preload argument of the stylesheet_tag filter", node: node)
       when "image"

--- a/lib/theme_check/checks/asset_preload.rb
+++ b/lib/theme_check/checks/asset_preload.rb
@@ -8,6 +8,8 @@ module ThemeCheck
     def on_link(node)
       return if node.attributes["rel"]&.downcase != "preload"
       case node.attributes["as"]&.downcase
+      when "font"
+        # Ignored as it is not supported
       when "style"
         add_offense("For better performance, prefer using the preload argument of the stylesheet_tag filter", node: node)
       when "image"

--- a/test/checks/asset_preload_test.rb
+++ b/test/checks/asset_preload_test.rb
@@ -6,7 +6,7 @@ class AssetPreloadTest < Minitest::Test
     offenses = analyze_theme(
       ThemeCheck::AssetPreload.new,
       "templates/index.liquid" => <<~END,
-        <link href="a.css" rel="stylesheet">
+        <link href="{{ 'a.css' | asset_url }}" rel="stylesheet">
         <link href="b.com" rel="preconnect">
       END
     )
@@ -23,11 +23,21 @@ class AssetPreloadTest < Minitest::Test
     assert_offenses("", offenses)
   end
 
+  def test_no_warning_for_external_assets
+    offenses = analyze_theme(
+      ThemeCheck::AssetPreload.new,
+      "templates/index.liquid" => <<~END,
+        <link rel="preload" as="script" href="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js">
+      END
+    )
+    assert_offenses("", offenses)
+  end
+
   def test_reports_stylesheet_preloading
     offenses = analyze_theme(
       ThemeCheck::AssetPreload.new,
       "templates/index.liquid" => <<~END,
-        <link href="a.css" rel="preload" as="style">
+        <link href="{{ 'a.css' | asset_url }}" rel="preload" as="style">
       END
     )
     assert_offenses(<<~END, offenses)
@@ -39,7 +49,7 @@ class AssetPreloadTest < Minitest::Test
     offenses = analyze_theme(
       ThemeCheck::AssetPreload.new,
       "templates/index.liquid" => <<~END,
-        <link href="a.png" rel="preload" as="image">
+        <link href="{{ 'a.png' | image_url }}" rel="preload" as="image">
       END
     )
     assert_offenses(<<~END, offenses)
@@ -51,7 +61,7 @@ class AssetPreloadTest < Minitest::Test
     offenses = analyze_theme(
       ThemeCheck::AssetPreload.new,
       "templates/index.liquid" => <<~END,
-        <link href="a..js" rel="preload" as="script">
+        <link href="{{ 'script.js' | asset_url  }}" rel="preload" as="script">
       END
     )
     assert_offenses(<<~END, offenses)

--- a/test/checks/asset_preload_test.rb
+++ b/test/checks/asset_preload_test.rb
@@ -13,6 +13,16 @@ class AssetPreloadTest < Minitest::Test
     assert_offenses("", offenses)
   end
 
+  def test_no_offense_for_font_preload
+    offenses = analyze_theme(
+      ThemeCheck::AssetPreload.new,
+      "templates/index.liquid" => <<~END,
+        <link as="font" href="{{ setting.type_body_font | font_url }}" rel="preload">
+      END
+    )
+    assert_offenses("", offenses)
+  end
+
   def test_reports_stylesheet_preloading
     offenses = analyze_theme(
       ThemeCheck::AssetPreload.new,


### PR DESCRIPTION
Fixes Shopify/theme-tools#411 by skipping font preload tags.

Also related to: https://github.com/Shopify/dawn/issues/1932 .