### PR TITLE
Add a new VariableName check

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -197,6 +197,9 @@ PaginationSize:
 DeprecatedGlobalAppBlockType:
   enabled: true
 
+VariableName:
+  enabled: true
+
 SchemaJsonFormat:
   enabled: true
   start_level: 0

--- a/docs/checks/variable_name.md
+++ b/docs/checks/variable_name.md
@@ -1,0 +1,51 @@
+# Enforce snake_case for variable names (`VariableName`)
+
+This check exists to enforce consistent naming of variables.
+
+## Check Details
+
+This checks requires variable names to be writen in `snake_case`.
+
+## Examples
+
+The following examples contain code snippets that either fail or pass this check.
+
+### &#x2717; Fail
+
+```liquid
+{{ myVariable }}
+{{ assign otherVariable = value }}
+```
+
+### &#x2713; Pass
+
+```liquid
+{{ my_variable }}
+{{ assign other_variable = value}}
+```
+
+
+## Check Options
+
+The default configuration for this check is the following:
+
+```yaml
+VariableName:
+  enabled: true
+```
+
+## When Not To Use It
+
+It's safe to disable this rule.
+
+## Version
+
+This check has been introduced in Theme Check 1.15.0.
+
+## Resources
+
+- [Rule source][codesource]
+- [Documentation source][docsource]
+
+[codesource]: /lib/theme_check/checks/variable_name.rb
+[docsource]: /docs/checks/variable_name.md

--- a/lib/theme_check/checks/variable_name.rb
+++ b/lib/theme_check/checks/variable_name.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module ThemeCheck
+  class VariableName < LiquidCheck
+    severity :suggestion
+    category :liquid
+    doc docs_url(__FILE__)
+
+    def on_assign(node)
+      check_variable_name(node, node.value.to)
+    end
+
+    def on_variable(node)
+      return unless node.value.name.is_a?(Liquid::VariableLookup)
+
+      check_variable_name(node, node.value.name.name)
+      node.value.name.lookups.each { |child| check_variable_name(node, child) }
+    end
+
+    private
+
+    def check_variable_name(node, variable)
+      variable = variable.name if variable.is_a?(Liquid::VariableLookup)
+
+      return if variable.match?(/^[\d[[:lower:]]_]+$/)
+
+      add_offense("Use snake_case for variable names", node: node)
+    end
+  end
+end

--- a/test/checks/variable_name_test.rb
+++ b/test/checks/variable_name_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+require "test_helper"
+class VariableNameTest < Minitest::Test
+  def test_assign_to_camel_case_variable
+    offenses = analyze_theme(
+      ThemeCheck::VariableName.new,
+      "templates/index.liquid" => <<~END,
+        {% assign camelCase = 1 %}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Use snake_case for variable names at templates/index.liquid:1
+    END
+  end
+
+  def test_using_camel_case_variable
+    offenses = analyze_theme(
+      ThemeCheck::VariableName.new,
+      "templates/index.liquid" => <<~END,
+        {{ camelCase }}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Use snake_case for variable names at templates/index.liquid:1
+    END
+  end
+
+  def test_using_camel_case_variable_with_filters
+    offenses = analyze_theme(
+      ThemeCheck::VariableName.new,
+      "templates/index.liquid" => <<~END,
+        {{ camelCase | t: b }}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Use snake_case for variable names at templates/index.liquid:1
+    END
+  end
+
+  def test_using_camel_case_on_object_property
+    offenses = analyze_theme(
+      ThemeCheck::VariableName.new,
+      "templates/index.liquid" => <<~END,
+        {{ shop.myTheme }}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Use snake_case for variable names at templates/index.liquid:1
+    END
+  end
+
+  def test_using_brackets
+    offenses = analyze_theme(
+      ThemeCheck::VariableName.new,
+      "templates/index.liquid" => <<~END,
+        {{ [myShop] }}
+      END
+    )
+    assert_offenses(<<~END, offenses)
+      Use snake_case for variable names at templates/index.liquid:1
+    END
+  end
+
+  def test_non_variables
+    offenses = analyze_theme(
+      ThemeCheck::VariableName.new,
+      "templates/index.liquid" => <<~END,
+        {{ 'camelCase' }}
+        {{ 'camelCase' | t: b }}
+      END
+    )
+    assert_offenses("", offenses)
+  end
+
+  def test_snake_case_usage
+    offenses = analyze_theme(
+      ThemeCheck::VariableName.new,
+      "templates/index.liquid" => <<~END,
+        {{ assign snake_case = true }}
+        {{ snake_case }}
+        {{ snake_case | t: b }}
+        {{ my_shop.my_theme }}
+        {{ [some_var] }}
+      END
+    )
+    assert_offenses("", offenses)
+  end
+end


### PR DESCRIPTION
Following https://github.com/Shopify/theme-tools/issues/447 this check requires that variable names use snake_case

This is my first theme check so any feedback is welcome. As a learning exercise, I intend to do ~all~ most of the checks suggested in Shopify/theme-tools#447 so if anything there is outdated, I'd appreciate updating.