### PR TITLE
[TAE] add section context to app blocks

### DIFF
--- a/data/shopify_liquid/theme_app_extension_labels.json
+++ b/data/shopify_liquid/theme_app_extension_labels.json
@@ -1,3 +1,4 @@
 [
-  "app"
+  "app",
+  "section"
 ]


### PR DESCRIPTION
### What are you trying to accomplish?

Although initially the `section` object was not a valid local-global variable inside app-block context, we are re-introducing it which will allow app-block developers to leverage it to consume section rendering APIs.

Important to note that only the ID property will be exposed.
