### PR TITLE
Bump theme-check version to 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+v1.15.0 / 2023-04-14
+==================
+
+  * Improve rule for lazy loading to prevent developers from overusing it
+  * Introduce `--update-docs` flag to synchronously update Theme Check resources (objects, filters, and tags) (#707)
+
 v1.14.0 / 2023-01-10
 ==================
 

--- a/lib/theme_check/version.rb
+++ b/lib/theme_check/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ThemeCheck
-  VERSION = "1.14.0"
+  VERSION = "1.15.0"
 end


### PR DESCRIPTION
v1.15.0 / 2023-04-14
==================

  * Improve rule for lazy loading to prevent developers from overusing it ([#723](https://github.com/Shopify/theme-check/issues/723))
  * Introduce `--update-docs` flag to synchronously update Theme Check resources (objects, filters, and tags) ([#707](https://github.com/Shopify/theme-check/issues/707))