### PR TITLE
Add rule to detect redundant preconnect to Shopify CDN

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -150,6 +150,10 @@ AssetSizeCSSStylesheetTag:
   threshold_in_bytes: 100_000
   ignore: []
 
+CdnPreconnect:
+  enabled: true
+  ignore: []
+
 ImgWidthAndHeight:
   enabled: true
   ignore: []

--- a/docs/checks/cdn_preconnect.md
+++ b/docs/checks/cdn_preconnect.md
@@ -1,0 +1,56 @@
+# Check Title (`CdnPreconnect`)
+
+_Version THEME_CHECK_VERSION+_
+
+The preconnect resource hint is a useful way of making sure connections to external domains are ready as soon as possible. It can improve performance by enabling the browser to start downloading critical assets right after discovering them in the HTML.
+
+Because every Shopify store makes use of `cdn.shopify.com`, the platform already includes the preconnect resource hint inside the `Link` header in the main document response. This makes the preconnect in the HTML redundant.
+
+With the rollout of [moving CDN assets to the main store domain](https://changelog.shopify.com/posts/changes-to-asset-urls), it becomes even more unnecessary as there may be no assets coming from `cdn.shopify.com`. In this case, the redundant preconnect can negatively impact performance.
+
+## Examples
+
+The following examples contain code snippets that either fail or pass this check.
+
+### &#x2717; Fail
+
+```liquid
+<link href="https://cdn.shopify.com" rel="preconnect">
+<link href="https://cdn.shopify.com" rel="preconnect" crossorigin>
+```
+
+### &#x2713; Pass
+
+```liquid
+<link href="https://example.com/" rel="preconnect">
+<link href="https://example.com/" rel="preconnect" crossorigin>
+```
+
+## Options
+
+The following example contains the default configuration for this check:
+
+```yaml
+CdnPreconnect:
+  enabled: true
+  severity: suggestion
+```
+
+| Parameter | Description |
+| --- | --- |
+| enabled | Whether the check is enabled. |
+| severity | The [severity](https://shopify.dev/themes/tools/theme-check/configuration#check-severity) of the check. |
+
+## Disabling this check
+
+Disabling this check isn't recommended because preconnect to Shopify's CDN is in the best case redundant and in the worst case negatively impacts performance.
+
+## Resources
+
+- [Introduction to resource hints][resourcehints]
+- [Rule source][codesource]
+- [Documentation source][docsource]
+
+[resourcehints]: https://performance.shopify.com/blogs/blog/introduction-to-resource-hints
+[codesource]: /lib/theme_check/checks/cdn_preconnect.rb
+[docsource]: /docs/checks/cdn_preconnect.md

--- a/lib/theme_check/checks/cdn_preconnect.rb
+++ b/lib/theme_check/checks/cdn_preconnect.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module ThemeCheck
+  class CdnPreconnect < HtmlCheck
+    severity :suggestion
+    categories :html, :performance
+    doc docs_url(__FILE__)
+
+    def on_link(node)
+      return if node.attributes["rel"]&.downcase != "preconnect"
+      return unless node.attributes["href"]&.downcase&.include?("cdn.shopify.com")
+      add_offense("Preconnecting to cdn.shopify.com is unnecessary and can lead to worse performance", node: node)
+    end
+  end
+end

--- a/test/checks/cdn_preconnect_test.rb
+++ b/test/checks/cdn_preconnect_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module ThemeCheck
+  class CdnPreconnectTest < Minitest::Test
+    def test_no_offense_with_other_external_domains
+      offenses = analyze_theme(
+        CdnPreconnect.new,
+        "templates/index.liquid" => <<~END,
+          <link rel="preconnect" href="https://example.com/">
+          <link rel="preconnect" href="https://example.com/" crossorigin>
+        END
+      )
+      assert_offenses("", offenses)
+    end
+
+    def test_no_offense_with_other_links
+      offenses = analyze_theme(
+        CdnPreconnect.new,
+        "templates/index.liquid" => <<~END,
+          <link rel="preload" href="https://example.com/foo.css" as="style">
+          <link rel="stylesheet" href="https://example.com/bar.css">
+          <link rel="icon">
+        END
+      )
+      assert_offenses("", offenses)
+    end
+
+    def test_reports_preconnect_to_shopify_cdn
+      offenses = analyze_theme(
+        CdnPreconnect.new,
+        "templates/index.liquid" => <<~END,
+          <link rel="preconnect" href="https://cdn.shopify.com/">
+        END
+      )
+      assert_offenses(<<~END, offenses)
+        Preconnecting to cdn.shopify.com is unnecessary and can lead to worse performance at templates/index.liquid:1
+      END
+    end
+
+    def test_reports_crossorigin_preconnect_to_shopify_cdn
+      offenses = analyze_theme(
+        CdnPreconnect.new,
+        "templates/index.liquid" => <<~END,
+          <link rel="preconnect" href="https://cdn.shopify.com/" crossorigin>
+        END
+      )
+      assert_offenses(<<~END, offenses)
+        Preconnecting to cdn.shopify.com is unnecessary and can lead to worse performance at templates/index.liquid:1
+      END
+    end
+  end
+end


### PR DESCRIPTION
The goal of this change is to add a rule that detects and discourages occurrences of:
```html
<link rel="preconnect" href="https://cdn.shopify.com">
```
I described why this kind of preconnect is redundant in the [PR to Dawn](https://github.com/Shopify/dawn/pull/2621).
