### PR TITLE
Fix an issue where the error message 'UndefinedObject: Undefined object section' is being incorrectly reported

### DIFF
--- a/lib/theme_check/shopify_liquid/source_index.rb
+++ b/lib/theme_check/shopify_liquid/source_index.rb
@@ -22,7 +22,7 @@ module ThemeCheck
             load_file(:objects)
               .concat(built_in_objects)
               .filter_map do |hash|
-                next if (theme_app_extension_labels + labels_only_exposed_in_certain_contexts).include?(hash['name'])
+                next if labels_only_exposed_in_certain_contexts.include?(hash['name'])
 
                 ObjectEntry.new(hash)
               end
@@ -45,7 +45,7 @@ module ThemeCheck
         end
 
         def labels_only_exposed_in_certain_contexts
-          ['robots'].freeze
+          ['robots', 'app'].freeze
         end
 
         def deprecated_filters

--- a/test/checks/undefined_object_test.rb
+++ b/test/checks/undefined_object_test.rb
@@ -450,6 +450,16 @@ class UndefinedObjectTest < Minitest::Test
     END
   end
 
+  def test_does_not_report_when_section_is_used
+    offenses = analyze_theme(
+      ThemeCheck::UndefinedObject.new(exclude_snippets: false),
+      "blocks/block_a.liquid" => <<~END,
+        <p>{{ section.id }}</p>
+      END
+    )
+    assert_offenses("", offenses)
+  end
+
   def test_does_not_report_on_app_liquid_drop_in_theme_app_extensions
     offenses = analyze_theme(
       ThemeCheck::UndefinedObject.new(exclude_snippets: false, config_type: :theme_app_extension),


### PR DESCRIPTION
### What are you trying to accomplish?

During my review and testing of the https://github.com/Shopify/theme-liquid-docs/pull/190 PR, I noticed that Theme Check was inaccurately flagging the `error: UndefinedObject: Undefined object 'section'` offense. This issue was caused by a minor change made in https://github.com/Shopify/theme-check/pull/725.

To resolve this problem, I changed the `SourceIndex` to no longer ignore all `theme_app_extension_labels`.

As https://github.com/Shopify/theme-check/pull/725 has not been released, I'm not introducing a changelog for this.

### How to test your changes?

- Run `./bin/theme-check <theme_path>`
- Notice that incorrect `error: UndefinedObject: Undefined object 'section'` errors are no longer reported