### PR TITLE
Fix Theme Check to be resilient when it's running offline without bundled resources

### DIFF
--- a/lib/theme_check/shopify_liquid/source_index.rb
+++ b/lib/theme_check/shopify_liquid/source_index.rb
@@ -56,6 +56,9 @@ module ThemeCheck
 
         def load_file(file_name)
           read_json(local_path!(file_name))
+        rescue StandardError
+          # If files get manually deleted, fallback with an empty list.
+          []
         end
 
         def local_path!(file_name)

--- a/test/shopify_liquid/source_manager_test.rb
+++ b/test/shopify_liquid/source_manager_test.rb
@@ -42,7 +42,18 @@ module ThemeCheck
 
         download_or_refresh_files
 
-        assert_test_documentation_up_to_date(tmp_dir)
+      ensure
+        FileUtils.remove_entry(@tmp_dir)
+      end
+
+      def test_download_when_a_request_error_happens
+        tmp_dir = Pathname.new("#{@tmp_dir}/new")
+
+        @source_manager_class.stubs(:open_uri).raises(SourceManager::DownloadResourceError)
+        @source_manager_class.stubs(:default_destination).returns(tmp_dir)
+
+        # Nothing is raised
+        download_or_refresh_files
       ensure
         FileUtils.remove_entry(@tmp_dir)
       end


### PR DESCRIPTION
### Why are these changes introduced?

Fixes https://github.com/Shopify/theme-check/issues/733

### How to test your changes?

- Include the `127.0.0.1       raw.githubusercontent.com` entry on your `/etc/hosts`
- Run `./bin/theme-check ../theme-check-check --update-docs`
- Notice Theme Check no longer fails

