### PR TITLE
Fix broken link to CONTRIBUTING.md in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,4 +193,4 @@ In VS Code, these can be set directly in your `settings.json`.
 
 ## Contributing
 
-For guidance on contributing, refer to this [doc](/CONTRIBUTING)
+For guidance on contributing, refer to this [doc](/CONTRIBUTING.md)


### PR DESCRIPTION
The link to the contributing guide in README was missing the `.md` extension, causing it to lead to a 404 page. This PR fixes the link to point to the correct `CONTRIBUTING.md` file.