### PR TITLE
Clarify Documentation

### DIFF
--- a/docs/checks/img_width_and_height.md
+++ b/docs/checks/img_width_and_height.md
@@ -52,7 +52,7 @@ ImgWidthAndHeight:
 
 There are some cases where you can avoid content-layout shift without needing the width and height attributes:
 
-- When the aspect-ratio of the displayed image should be independent of the uploaded image. In those cases, the solution is still the padding-top hack with an `overflow: hidden container`.
+- When the aspect-ratio of the displayed image should be independent of the uploaded image. In those cases, the solution is still the [padding-top hack][csstricks-ratio] with an `overflow: hidden container`.
 - When you are happy with the padding-top hack.
 
 In those cases, it is fine to disable this check with the comment. 
@@ -68,11 +68,13 @@ This check has been introduced in Theme Check 0.6.0.
 - [Cumulative Layout Shift Reference][cls]
 - [Codepen illustrating the impact of width and height on layout shift][codepenshift]
 - [Codepen illustrating the impact of width and height on lazy loading][codepenlazy]
+- [Article detailing how padding can be used to "hack" aspect ratios][csstricks-ratio]
 - [Rule Source][codesource]
 - [Documentation Source][docsource]
 
 [cls]: https://web.dev/cls/
 [codepenshift]: https://codepen.io/charlespwd/pen/YzpxPEp?editors=1100
 [codepenlazy]: https://codepen.io/charlespwd/pen/abZmqXJ?editors=0111
+[csstricks-ratio]: https://css-tricks.com/aspect-ratio-boxes/
 [codesource]: /lib/theme_check/checks/img_aspect_ratio.rb
 [docsource]: /docs/checks/img_aspect_ratio.md

--- a/docs/checks/img_width_and_height.md
+++ b/docs/checks/img_width_and_height.md
@@ -74,6 +74,5 @@ This check has been introduced in Theme Check 0.6.0.
 [cls]: https://web.dev/cls/
 [codepenshift]: https://codepen.io/charlespwd/pen/YzpxPEp?editors=1100
 [codepenlazy]: https://codepen.io/charlespwd/pen/abZmqXJ?editors=0111
-[aspect-ratio]: https://caniuse.com/mdn-css_properties_aspect-ratio
 [codesource]: /lib/theme_check/checks/img_aspect_ratio.rb
 [docsource]: /docs/checks/img_aspect_ratio.md

--- a/docs/checks/img_width_and_height.md
+++ b/docs/checks/img_width_and_height.md
@@ -52,7 +52,7 @@ ImgWidthAndHeight:
 
 There are some cases where you can avoid content-layout shift without needing the width and height attributes:
 
-- When the aspect-ratio of the displayed image should be independent of the uploaded image. In those cases, the solution is still the [padding-top hack][csstricks-ratio] with an `overflow: hidden container`.
+- When the aspect-ratio of the displayed image should be independent of the uploaded image. In those cases, the solution is still the [padding-top hack][csstricks-ratio] with an `overflow: hidden` container.
 - When you are happy with the padding-top hack.
 
 In those cases, it is fine to disable this check with the comment. 


### PR DESCRIPTION
Cleans up a bit of the `img_width_and_height` doc to make things clearer.

- Removes a reference definition that was not being used anywhere in the document
- Adds a reference link to clarify the "padding-top hack", which is not common knowledge, and provides further context to what a "padding-top hack" is and how it works.
- Fixes an error where the word "container" was places inside the small css snippet in error.`overflow: hidden container` makes it seems like `container` is a CSS value, when really what is means is "a container with `overflow: hidden` CSS rule applied to it".